### PR TITLE
Force marquee selection when holding Cmd during drag

### DIFF
--- a/packages/engine/src/tools/move-tool.ts
+++ b/packages/engine/src/tools/move-tool.ts
@@ -48,6 +48,21 @@ export class MoveTool extends BaseTool {
     this.spatialIndex.rebuild(shapes);
     const store = getToolStore();
 
+    if (ctx.metaKey) {
+      const preMarqueeIds = ctx.shiftKey ? [...store.selectedIds] : [];
+      if (!ctx.shiftKey) {
+        store.clearSelection();
+        store.setEnteredGroupId(null);
+      }
+      this.state = {
+        type: 'marquee',
+        startCanvas: { x: ctx.canvasPoint.x, y: ctx.canvasPoint.y },
+        preMarqueeIds,
+      };
+      this.marqueeRect = null;
+      return;
+    }
+
     if (store.selectedIds.length > 0) {
       const selectedShapes = store.selectedIds
         .map((id) => shapes.find((s) => s.id === id))


### PR DESCRIPTION
## Summary
- Holding Cmd (⌘) while dragging on the canvas now forces marquee selection, bypassing shape/group hit-testing and drag behavior
- Supports Shift+Cmd to add to the existing selection via marquee

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)