### PR TITLE
Fix inspect preview and codegen layout

### DIFF
--- a/apps/web/src/pages/editor/components/inspect-panel/index.tsx
+++ b/apps/web/src/pages/editor/components/inspect-panel/index.tsx
@@ -55,7 +55,7 @@ export function InspectPanel({ ydoc }: InspectPanelProps) {
   void revision;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <span className="text-muted-foreground text-[11px] font-medium">Dev Mode</span>
         <div className="flex items-center gap-1">
@@ -71,11 +71,17 @@ export function InspectPanel({ ydoc }: InspectPanelProps) {
         </div>
       </div>
       {activeTab === 'preview' ? (
-        <InspectPreview ydoc={ydoc} shapes={shapes} />
+        <div className="min-h-0 flex-1">
+          <InspectPreview ydoc={ydoc} shapes={shapes} />
+        </div>
       ) : activeTab === 'code' ? (
-        <InspectCode ydoc={ydoc} shapes={shapes} />
+        <div className="min-h-0 flex-1 overflow-auto">
+          <InspectCode ydoc={ydoc} shapes={shapes} />
+        </div>
       ) : (
-        <InspectListView shapes={shapes} />
+        <div className="min-h-0 flex-1 overflow-auto">
+          <InspectListView shapes={shapes} />
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/pages/editor/components/inspect-panel/inspect-preview.tsx
+++ b/apps/web/src/pages/editor/components/inspect-panel/inspect-preview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type * as Y from 'yjs';
 import { Copy, Check, Download, ChevronDown } from 'lucide-react';
 import type { Shape } from '@draftila/shared';
@@ -86,18 +86,71 @@ function downloadFile(content: string, filename: string, type: string) {
   URL.revokeObjectURL(url);
 }
 
+function getContentBounds(shapes: Shape[]): { width: number; height: number } | null {
+  const roots = shapes.filter((s) => !s.parentId || !shapes.some((p) => p.id === s.parentId));
+  if (roots.length === 0) return null;
+  let maxW = 0;
+  let maxH = 0;
+  for (const s of roots) {
+    maxW = Math.max(maxW, s.width);
+    maxH = Math.max(maxH, s.height);
+  }
+  return { width: maxW, height: maxH };
+}
+
+function useContainerSize(ref: React.RefObject<HTMLDivElement | null>) {
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        setSize({ width: entry.contentRect.width, height: entry.contentRect.height });
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return size;
+}
+
+function injectScaleStyle(html: string, scale: number, contentWidth: number): string {
+  const centeredLeft = `calc(50% - ${Math.round((contentWidth * scale) / 2)}px)`;
+  const scaleStyle =
+    `<style>body{display:block!important;padding:0!important;margin:0!important;}` +
+    `body>*:first-child{transform:scale(${scale});transform-origin:top left;` +
+    `position:relative;left:${centeredLeft};}</style>`;
+  return html.replace('</head>', `${scaleStyle}</head>`);
+}
+
 export function InspectPreview({ ydoc, shapes }: InspectPreviewProps) {
   const [mode, setMode] = useState<PreviewMode>('css');
   const [view, setView] = useState<PreviewView>('preview');
   const [copied, setCopied] = useState(false);
   const expandedShapes = useExpandedShapes(ydoc, shapes);
   const tailwindScript = useTailwindScript();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const containerSize = useContainerSize(containerRef);
 
   const html = useMemo(() => {
     if (expandedShapes.length === 0) return '';
     if (mode === 'css') return generateHtmlCss(expandedShapes);
     return generateHtmlTailwind(expandedShapes, tailwindScript ?? undefined);
   }, [expandedShapes, mode, tailwindScript]);
+
+  const previewHtml = useMemo(() => {
+    if (!html || !containerSize) return html;
+    const bounds = getContentBounds(expandedShapes);
+    if (!bounds || bounds.width === 0 || bounds.height === 0) return html;
+    const scaleX = containerSize.width / bounds.width;
+    const scaleY = containerSize.height / bounds.height;
+    const scale = Math.min(scaleX, scaleY, 1);
+    if (scale >= 1) return html;
+    return injectScaleStyle(html, scale, bounds.width);
+  }, [html, containerSize, expandedShapes]);
 
   const parts = useMemo(() => {
     if (mode !== 'css' || expandedShapes.length === 0) return null;
@@ -169,10 +222,10 @@ export function InspectPreview({ ydoc, shapes }: InspectPreviewProps) {
           />
         </div>
       </div>
-      <div className="min-h-0 flex-1">
+      <div ref={containerRef} className="min-h-0 flex-1">
         {view === 'preview' ? (
           <iframe
-            srcDoc={html}
+            srcDoc={previewHtml}
             sandbox="allow-scripts"
             className="h-full w-full border-0 bg-white"
             title="Live Preview"

--- a/apps/web/src/pages/editor/components/right-panel.tsx
+++ b/apps/web/src/pages/editor/components/right-panel.tsx
@@ -240,7 +240,7 @@ function DevModePanel({ ydoc }: { ydoc: Y.Doc }) {
   return (
     <div className={`flex h-full ${panelWidth} shrink-0 flex-col border-l transition-[width]`}>
       <ZoomControls ydoc={ydoc} />
-      <div className="flex-1 overflow-auto">
+      <div className="min-h-0 flex-1">
         <InspectPanel ydoc={ydoc} />
       </div>
     </div>

--- a/packages/engine/src/codegen/css-generator.ts
+++ b/packages/engine/src/codegen/css-generator.ts
@@ -11,7 +11,7 @@ import type {
   ImageShape,
   EllipseShape,
 } from '@draftila/shared';
-import type { ShapeTreeNode } from './types';
+import type { ShapeTreeNode, ShapeContext } from './types';
 import {
   hexToRgba,
   rgbaToCssColor,
@@ -24,6 +24,7 @@ import {
   getEffectiveCornerRadii,
   buildShapeTree,
   gradientToCssValue,
+  childContextForShape,
 } from './helpers';
 
 export function generateCss(shapes: Shape[]): string {
@@ -38,7 +39,7 @@ export function generateCssAllLayers(shapes: Shape[]): string {
   const blocks: string[] = [];
   const usedNames = new Map<string, number>();
 
-  function walkTree(node: ShapeTreeNode, parentSelector: string) {
+  function walkTree(node: ShapeTreeNode, parentSelector: string, ctx?: ShapeContext) {
     if (!node.shape.visible) return;
 
     const baseName = sanitizeName(node.shape.name, node.shape.type);
@@ -47,13 +48,14 @@ export function generateCssAllLayers(shapes: Shape[]): string {
     const className = count > 0 ? `${baseName}-${count + 1}` : baseName;
     const selector = parentSelector ? `${parentSelector} .${className}` : `.${className}`;
 
-    const props = shapeToProperties(node.shape);
+    const props = shapeToProperties(node.shape, ctx);
     if (props.length > 0) {
       blocks.push(`${selector} {\n${props.map((p) => `  ${p}`).join('\n')}\n}`);
     }
 
+    const childCtx = childContextForShape(node.shape);
     for (const child of node.children) {
-      walkTree(child, selector);
+      walkTree(child, selector, childCtx);
     }
   }
 
@@ -70,30 +72,30 @@ function generateNodeCss(shape: Shape): string {
   return props.join('\n');
 }
 
-export function shapeToProperties(shape: Shape): string[] {
+export function shapeToProperties(shape: Shape, ctx?: ShapeContext): string[] {
   switch (shape.type) {
     case 'rectangle':
-      return rectangleProperties(shape);
+      return rectangleProperties(shape, ctx);
     case 'ellipse':
-      return ellipseProperties(shape);
+      return ellipseProperties(shape, ctx);
     case 'frame':
-      return frameProperties(shape);
+      return frameProperties(shape, ctx);
     case 'text':
-      return textProperties(shape);
+      return textProperties(shape, ctx);
     case 'path':
-      return vectorProperties(shape);
+      return vectorProperties(shape, ctx);
     case 'polygon':
-      return vectorProperties(shape);
+      return vectorProperties(shape, ctx);
     case 'star':
-      return vectorProperties(shape);
+      return vectorProperties(shape, ctx);
     case 'line':
-      return lineProperties(shape);
+      return lineProperties(shape, ctx);
     case 'image':
-      return imageProperties(shape);
+      return imageProperties(shape, ctx);
     case 'svg':
-      return baseDimensionProperties(shape);
+      return baseDimensionProperties(shape, ctx);
     case 'group':
-      return baseDimensionProperties(shape);
+      return groupProperties(shape, ctx);
   }
 }
 
@@ -113,8 +115,22 @@ function minMaxToCss(shape: Shape): string[] {
   return props;
 }
 
-function baseDimensionProperties(shape: Shape): string[] {
+function absolutePositionToCss(shape: Shape, ctx: ShapeContext): string[] {
+  const relX = shape.x - (ctx.parentX ?? 0);
+  const relY = shape.y - (ctx.parentY ?? 0);
   const props: string[] = [];
+  props.push('position: absolute;');
+  props.push(`left: ${roundTo(relX, 1)}px;`);
+  props.push(`top: ${roundTo(relY, 1)}px;`);
+  return props;
+}
+
+function baseDimensionProperties(shape: Shape, ctx?: ShapeContext): string[] {
+  const props: string[] = [];
+
+  if (ctx?.needsAbsolutePosition) {
+    props.push(...absolutePositionToCss(shape, ctx));
+  }
 
   if (shape.layoutSizingHorizontal === 'fill') {
     props.push('flex: 1;');
@@ -268,8 +284,8 @@ function cornerRadiusToCss(shape: Shape): string[] {
   ];
 }
 
-function rectangleProperties(shape: RectangleShape): string[] {
-  const props = baseDimensionProperties(shape);
+function rectangleProperties(shape: RectangleShape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
   props.push(...cornerRadiusToCss(shape));
   props.push(...fillsToCss(shape.fills));
   props.push(...strokesToCss(shape.strokes));
@@ -278,8 +294,9 @@ function rectangleProperties(shape: RectangleShape): string[] {
   return props;
 }
 
-function ellipseProperties(shape: EllipseShape): string[] {
-  const props = baseDimensionProperties(shape);
+function ellipseProperties(shape: EllipseShape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
+  if (ctx?.layoutOnly) return props;
   props.push('border-radius: 50%;');
   props.push(...fillsToCss(shape.fills));
   props.push(...strokesToCss(shape.strokes));
@@ -288,8 +305,8 @@ function ellipseProperties(shape: EllipseShape): string[] {
   return props;
 }
 
-function frameProperties(shape: FrameShape): string[] {
-  const props = baseDimensionProperties(shape);
+function frameProperties(shape: FrameShape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
   props.push(...cornerRadiusToCss(shape));
   props.push(...fillsToCss(shape.fills));
   props.push(...strokesToCss(shape.strokes));
@@ -323,8 +340,16 @@ function frameProperties(shape: FrameShape): string[] {
     props.push(...paddingToCss(shape));
     props.push(`align-items: ${layoutAlignToCss(shape.layoutAlign)};`);
     props.push(`justify-content: ${layoutJustifyToCss(shape.layoutJustify)};`);
+  } else {
+    props.push('position: relative;');
   }
 
+  return props;
+}
+
+function groupProperties(shape: Shape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
+  props.push('position: relative;');
   return props;
 }
 
@@ -376,8 +401,8 @@ function layoutJustifyToCss(justify: FrameShape['layoutJustify']): string {
   }
 }
 
-function textProperties(shape: TextShape): string[] {
-  const props = baseDimensionProperties(shape);
+function textProperties(shape: TextShape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
 
   props.push(`font-family: '${escapeCssSingleQuotedString(shape.fontFamily)}';`);
   props.push(`font-size: ${roundTo(shape.fontSize, 1)}px;`);
@@ -435,8 +460,9 @@ function textProperties(shape: TextShape): string[] {
   return props;
 }
 
-function vectorProperties(shape: Shape): string[] {
-  const props = baseDimensionProperties(shape);
+function vectorProperties(shape: Shape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
+  if (ctx?.layoutOnly) return props;
 
   const svgPathData =
     'svgPathData' in shape ? (shape.svgPathData as string | undefined) : undefined;
@@ -460,13 +486,22 @@ function vectorProperties(shape: Shape): string[] {
   return props;
 }
 
-function lineProperties(shape: LineShape): string[] {
+function lineProperties(shape: LineShape, ctx?: ShapeContext): string[] {
   const dx = shape.x2 - shape.x1;
   const dy = shape.y2 - shape.y1;
   const length = Math.sqrt(dx * dx + dy * dy);
   const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
 
   const props: string[] = [];
+
+  if (ctx?.needsAbsolutePosition) {
+    const relX = shape.x + shape.x1 - (ctx.parentX ?? 0);
+    const relY = shape.y + shape.y1 - (ctx.parentY ?? 0);
+    props.push('position: absolute;');
+    props.push(`left: ${roundTo(relX, 1)}px;`);
+    props.push(`top: ${roundTo(relY, 1)}px;`);
+  }
+
   props.push(`width: ${roundTo(length, 1)}px;`);
   props.push('height: 0;');
 
@@ -494,8 +529,8 @@ function lineProperties(shape: LineShape): string[] {
   return props;
 }
 
-function imageProperties(shape: ImageShape): string[] {
-  const props = baseDimensionProperties(shape);
+function imageProperties(shape: ImageShape, ctx?: ShapeContext): string[] {
+  const props = baseDimensionProperties(shape, ctx);
 
   const fitMap: Record<ImageShape['fit'], string> = {
     fill: 'cover',

--- a/packages/engine/src/codegen/helpers.ts
+++ b/packages/engine/src/codegen/helpers.ts
@@ -1,5 +1,6 @@
-import type { Fill, Stroke, Shadow, Blur, Shape } from '@draftila/shared';
-import type { ShapeTreeNode } from './types';
+import type { Fill, Stroke, Shadow, Blur, Shape, FrameShape } from '@draftila/shared';
+import type { ShapeTreeNode, ShapeContext } from './types';
+import { shapesToInterchange, generateSvg } from '../interchange';
 
 export interface Rgba {
   r: number;
@@ -187,4 +188,29 @@ export function deduplicateNames(names: string[]): Map<string, string> {
   }
 
   return result;
+}
+
+export function childContextForShape(shape: Shape): ShapeContext | undefined {
+  if (shape.type === 'frame') {
+    const frame = shape as FrameShape;
+    if (frame.layoutMode === 'none') {
+      return { needsAbsolutePosition: true, parentX: shape.x, parentY: shape.y };
+    }
+  }
+  if (shape.type === 'group') {
+    return { needsAbsolutePosition: true, parentX: shape.x, parentY: shape.y };
+  }
+  return undefined;
+}
+
+const VECTOR_TYPES = new Set(['path', 'polygon', 'star', 'ellipse']);
+
+export function isVectorShape(shape: Shape): boolean {
+  return VECTOR_TYPES.has(shape.type);
+}
+
+export function shapeToInlineSvg(shape: Shape): string {
+  const normalized: Shape = { ...shape, x: 0, y: 0, rotation: 0, opacity: 1 };
+  const doc = shapesToInterchange([normalized]);
+  return generateSvg(doc);
 }

--- a/packages/engine/src/codegen/html-generator.ts
+++ b/packages/engine/src/codegen/html-generator.ts
@@ -1,6 +1,15 @@
 import type { Shape, TextShape, ImageShape, SvgShape, TextSegment } from '@draftila/shared';
-import type { ShapeTreeNode } from './types';
-import { buildShapeTree, sanitizeName, indent, escapeHtml, sanitizeSvgContent } from './helpers';
+import type { ShapeTreeNode, ShapeContext } from './types';
+import {
+  buildShapeTree,
+  sanitizeName,
+  indent,
+  escapeHtml,
+  sanitizeSvgContent,
+  childContextForShape,
+  isVectorShape,
+  shapeToInlineSvg,
+} from './helpers';
 import { shapeToProperties } from './css-generator';
 import { shapeToClasses } from './tailwind-generator';
 
@@ -45,17 +54,23 @@ function textSegmentToTailwindClasses(segment: TextSegment): string[] {
   return classes;
 }
 
-function nodeToHtmlCss(node: ShapeTreeNode, ctx: CssContext, depth: number): string {
+function nodeToHtmlCss(
+  node: ShapeTreeNode,
+  ctx: CssContext,
+  depth: number,
+  shapeCtx?: ShapeContext,
+): string {
   if (!node.shape.visible) return '';
 
-  const className = uniqueClassName(node.shape.name, node.shape.type, ctx.usedNames);
-  const cssProps = shapeToProperties(node.shape);
+  const shape = node.shape;
+  const isVector = isVectorShape(shape);
+  const effectiveCtx = isVector ? { ...shapeCtx, layoutOnly: true } : shapeCtx;
+  const className = uniqueClassName(shape.name, shape.type, ctx.usedNames);
+  const cssProps = shapeToProperties(shape, effectiveCtx);
 
   if (cssProps.length > 0) {
     ctx.cssBlocks.push(`.${className} {\n${cssProps.map((p) => `  ${p}`).join('\n')}\n}`);
   }
-
-  const shape = node.shape;
 
   if (shape.type === 'text') {
     const textShape = shape as TextShape;
@@ -78,10 +93,16 @@ function nodeToHtmlCss(node: ShapeTreeNode, ctx: CssContext, depth: number): str
     return indent(`<div class="${className}"></div>`, depth);
   }
 
+  if (isVector) {
+    const svg = shapeToInlineSvg(shape);
+    return indent(`<div class="${className}">\n  ${svg}\n</div>`, depth);
+  }
+
   const isContainer = shape.type === 'frame' || shape.type === 'group';
   if (isContainer && node.children.length > 0) {
+    const childCtx = childContextForShape(shape);
     const childrenHtml = node.children
-      .map((child) => nodeToHtmlCss(child, ctx, depth + 1))
+      .map((child) => nodeToHtmlCss(child, ctx, depth + 1, childCtx))
       .filter(Boolean)
       .join('\n');
     return (
@@ -113,11 +134,13 @@ function renderTextContentCss(shape: TextShape, _parentClass: string, ctx: CssCo
     .join('');
 }
 
-function nodeToHtmlTailwind(node: ShapeTreeNode, depth: number): string {
+function nodeToHtmlTailwind(node: ShapeTreeNode, depth: number, shapeCtx?: ShapeContext): string {
   if (!node.shape.visible) return '';
 
-  const classes = shapeToClasses(node.shape).join(' ');
   const shape = node.shape;
+  const isVector = isVectorShape(shape);
+  const effectiveCtx = isVector ? { ...shapeCtx, layoutOnly: true } : shapeCtx;
+  const classes = shapeToClasses(shape, effectiveCtx).join(' ');
 
   if (shape.type === 'text') {
     const textShape = shape as TextShape;
@@ -140,10 +163,16 @@ function nodeToHtmlTailwind(node: ShapeTreeNode, depth: number): string {
     return indent(`<div class="${classes}"></div>`, depth);
   }
 
+  if (isVector) {
+    const svg = shapeToInlineSvg(shape);
+    return indent(`<div class="${classes}">\n  ${svg}\n</div>`, depth);
+  }
+
   const isContainer = shape.type === 'frame' || shape.type === 'group';
   if (isContainer && node.children.length > 0) {
+    const childCtx = childContextForShape(shape);
     const childrenHtml = node.children
-      .map((child) => nodeToHtmlTailwind(child, depth + 1))
+      .map((child) => nodeToHtmlTailwind(child, depth + 1, childCtx))
       .filter(Boolean)
       .join('\n');
     return (

--- a/packages/engine/src/codegen/tailwind-generator.ts
+++ b/packages/engine/src/codegen/tailwind-generator.ts
@@ -11,7 +11,7 @@ import type {
   ImageShape,
   EllipseShape,
 } from '@draftila/shared';
-import type { ShapeTreeNode } from './types';
+import type { ShapeTreeNode, ShapeContext } from './types';
 import {
   hexToRgba,
   rgbaToCssColor,
@@ -24,6 +24,7 @@ import {
   getEffectiveCornerRadii,
   buildShapeTree,
   gradientToCssValue,
+  childContextForShape,
 } from './helpers';
 
 function spacingClass(prefix: string, px: number): string {
@@ -143,7 +144,7 @@ export function generateTailwindAllLayers(shapes: Shape[]): string {
   const blocks: string[] = [];
   const usedNames = new Map<string, number>();
 
-  function walkTree(node: ShapeTreeNode, parentSelector: string) {
+  function walkTree(node: ShapeTreeNode, parentSelector: string, ctx?: ShapeContext) {
     if (!node.shape.visible) return;
 
     const baseName = sanitizeName(node.shape.name, node.shape.type);
@@ -152,13 +153,14 @@ export function generateTailwindAllLayers(shapes: Shape[]): string {
     const className = count > 0 ? `${baseName}-${count + 1}` : baseName;
     const selector = parentSelector ? `${parentSelector} .${className}` : `.${className}`;
 
-    const classes = shapeToClasses(node.shape);
+    const classes = shapeToClasses(node.shape, ctx);
     if (classes.length > 0) {
       blocks.push(`${selector} {\n  @apply ${classes.join(' ')};\n}`);
     }
 
+    const childCtx = childContextForShape(node.shape);
     for (const child of node.children) {
-      walkTree(child, selector);
+      walkTree(child, selector, childCtx);
     }
   }
 
@@ -169,30 +171,30 @@ export function generateTailwindAllLayers(shapes: Shape[]): string {
   return blocks.join('\n\n');
 }
 
-export function shapeToClasses(shape: Shape): string[] {
+export function shapeToClasses(shape: Shape, ctx?: ShapeContext): string[] {
   switch (shape.type) {
     case 'rectangle':
-      return rectangleClasses(shape);
+      return rectangleClasses(shape, ctx);
     case 'ellipse':
-      return ellipseClasses(shape);
+      return ellipseClasses(shape, ctx);
     case 'frame':
-      return frameClasses(shape);
+      return frameClasses(shape, ctx);
     case 'text':
-      return textClasses(shape);
+      return textClasses(shape, ctx);
     case 'path':
-      return vectorClasses(shape);
+      return vectorClasses(shape, ctx);
     case 'polygon':
-      return vectorClasses(shape);
+      return vectorClasses(shape, ctx);
     case 'star':
-      return vectorClasses(shape);
+      return vectorClasses(shape, ctx);
     case 'line':
-      return lineClasses(shape);
+      return lineClasses(shape, ctx);
     case 'image':
-      return imageClasses(shape);
+      return imageClasses(shape, ctx);
     case 'svg':
-      return baseDimensionClasses(shape);
+      return baseDimensionClasses(shape, ctx);
     case 'group':
-      return baseDimensionClasses(shape);
+      return groupClasses(shape, ctx);
   }
 }
 
@@ -213,8 +215,18 @@ function minMaxToTailwind(shape: Shape): string[] {
   return classes;
 }
 
-function baseDimensionClasses(shape: Shape): string[] {
+function absolutePositionToTailwind(shape: Shape, ctx: ShapeContext): string[] {
+  const relX = shape.x - (ctx.parentX ?? 0);
+  const relY = shape.y - (ctx.parentY ?? 0);
+  return ['absolute', `left-[${roundTo(relX, 1)}px]`, `top-[${roundTo(relY, 1)}px]`];
+}
+
+function baseDimensionClasses(shape: Shape, ctx?: ShapeContext): string[] {
   const classes: string[] = [];
+
+  if (ctx?.needsAbsolutePosition) {
+    classes.push(...absolutePositionToTailwind(shape, ctx));
+  }
 
   if (shape.layoutSizingHorizontal === 'fill') {
     classes.push('flex-1', 'self-stretch');
@@ -467,8 +479,8 @@ function cornerRadiusToTailwind(shape: Shape): string[] {
   ];
 }
 
-function rectangleClasses(shape: RectangleShape): string[] {
-  const classes = baseDimensionClasses(shape);
+function rectangleClasses(shape: RectangleShape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
   classes.push(...cornerRadiusToTailwind(shape));
   classes.push(...fillsToTailwind(shape.fills));
   classes.push(...strokesToTailwind(shape.strokes));
@@ -477,8 +489,9 @@ function rectangleClasses(shape: RectangleShape): string[] {
   return classes;
 }
 
-function ellipseClasses(shape: EllipseShape): string[] {
-  const classes = baseDimensionClasses(shape);
+function ellipseClasses(shape: EllipseShape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
+  if (ctx?.layoutOnly) return classes;
   classes.push('rounded-full');
   classes.push(...fillsToTailwind(shape.fills));
   classes.push(...strokesToTailwind(shape.strokes));
@@ -487,8 +500,8 @@ function ellipseClasses(shape: EllipseShape): string[] {
   return classes;
 }
 
-function frameClasses(shape: FrameShape): string[] {
-  const classes = baseDimensionClasses(shape);
+function frameClasses(shape: FrameShape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
   classes.push(...cornerRadiusToTailwind(shape));
   classes.push(...fillsToTailwind(shape.fills));
   classes.push(...strokesToTailwind(shape.strokes));
@@ -522,8 +535,16 @@ function frameClasses(shape: FrameShape): string[] {
     classes.push(...paddingToTailwind(shape));
     classes.push(layoutAlignToTailwind(shape.layoutAlign));
     classes.push(layoutJustifyToTailwind(shape.layoutJustify));
+  } else {
+    classes.push('relative');
   }
 
+  return classes;
+}
+
+function groupClasses(shape: Shape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
+  classes.push('relative');
   return classes;
 }
 
@@ -590,8 +611,8 @@ const FONT_WEIGHT_MAP: Record<number, string> = {
   900: 'font-black',
 };
 
-function textClasses(shape: TextShape): string[] {
-  const classes = baseDimensionClasses(shape);
+function textClasses(shape: TextShape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
 
   classes.push(`font-['${shape.fontFamily.replaceAll(' ', '_')}']`);
   classes.push(fontSizeClass(shape.fontSize));
@@ -643,8 +664,9 @@ function textClasses(shape: TextShape): string[] {
   return classes;
 }
 
-function vectorClasses(shape: Shape): string[] {
-  const classes = baseDimensionClasses(shape);
+function vectorClasses(shape: Shape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
+  if (ctx?.layoutOnly) return classes;
 
   const svgPathData =
     'svgPathData' in shape ? (shape.svgPathData as string | undefined) : undefined;
@@ -668,13 +690,20 @@ function vectorClasses(shape: Shape): string[] {
   return classes;
 }
 
-function lineClasses(shape: LineShape): string[] {
+function lineClasses(shape: LineShape, ctx?: ShapeContext): string[] {
   const dx = shape.x2 - shape.x1;
   const dy = shape.y2 - shape.y1;
   const length = Math.sqrt(dx * dx + dy * dy);
   const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
 
   const classes: string[] = [];
+
+  if (ctx?.needsAbsolutePosition) {
+    const relX = shape.x + shape.x1 - (ctx.parentX ?? 0);
+    const relY = shape.y + shape.y1 - (ctx.parentY ?? 0);
+    classes.push('absolute', `left-[${roundTo(relX, 1)}px]`, `top-[${roundTo(relY, 1)}px]`);
+  }
+
   classes.push(`w-[${roundTo(length, 1)}px]`);
   classes.push('h-0');
 
@@ -702,8 +731,8 @@ function lineClasses(shape: LineShape): string[] {
   return classes;
 }
 
-function imageClasses(shape: ImageShape): string[] {
-  const classes = baseDimensionClasses(shape);
+function imageClasses(shape: ImageShape, ctx?: ShapeContext): string[] {
+  const classes = baseDimensionClasses(shape, ctx);
 
   const fitMap: Record<ImageShape['fit'], string> = {
     fill: 'object-cover',

--- a/packages/engine/src/codegen/types.ts
+++ b/packages/engine/src/codegen/types.ts
@@ -14,3 +14,10 @@ export interface ShapeTreeNode {
   shape: Shape;
   children: ShapeTreeNode[];
 }
+
+export interface ShapeContext {
+  needsAbsolutePosition?: boolean;
+  parentX?: number;
+  parentY?: number;
+  layoutOnly?: boolean;
+}


### PR DESCRIPTION
## Summary
- fix inspect panel sizing so preview/code/list tabs fill and scroll correctly in dev mode.
- scale live HTML preview to fit the available viewport while preserving aspect ratio.
- correct CSS/Tailwind codegen positioning for non-auto-layout/group children and render vector shapes as inline SVG.