### PR TITLE
Remove editor dev mode and add inspect view

### DIFF
--- a/apps/web/src/pages/editor/components/canvas-context-menu.tsx
+++ b/apps/web/src/pages/editor/components/canvas-context-menu.tsx
@@ -109,7 +109,6 @@ export const CanvasContextMenu = forwardRef<HTMLDivElement, CanvasContextMenuPro
     const [subSubMenu, setSubSubMenu] = useState<SubMenuState | null>(null);
 
     const selectedIds = useEditorStore((s) => s.selectedIds);
-    const devMode = useEditorStore((s) => s.devMode);
     const selectedGuideId = useEditorStore((s) => s.selectedGuideId);
     const guides = useEditorStore((s) => s.guides);
     const activePageId = useEditorStore((s) => s.activePageId);
@@ -376,61 +375,6 @@ export const CanvasContextMenu = forwardRef<HTMLDivElement, CanvasContextMenuPro
 
     const isMac = navigator.platform.includes('Mac');
     const mod = isMac ? '\u2318' : 'Ctrl+';
-
-    if (devMode) {
-      return (
-        <div ref={ref}>
-          <div
-            className="bg-popover text-popover-foreground fixed z-50 min-w-52 rounded-md border p-1 shadow-lg"
-            style={{ left: position.x, top: position.y }}
-          >
-            <MenuItem onClick={handleCopy} disabled={!hasSelection} shortcut={`${mod}C`}>
-              Copy
-            </MenuItem>
-            <MenuSeparator />
-            <MenuItem onClick={handleCopyAsSvg} disabled={!hasSelection}>
-              Copy as SVG
-            </MenuItem>
-            <MenuItem onClick={handleCopyAsPng} disabled={!hasSelection}>
-              Copy as PNG
-            </MenuItem>
-            <MenuSeparator />
-            <MenuItem onClick={() => handleCopyAsCode('css')} disabled={!hasSelection}>
-              Copy CSS
-            </MenuItem>
-            <MenuItem onClick={() => handleCopyAsCode('css-all-layers')} disabled={!hasSelection}>
-              Copy CSS (all layers)
-            </MenuItem>
-            <MenuItem onClick={() => handleCopyAsCode('tailwind')} disabled={!hasSelection}>
-              Copy Tailwind
-            </MenuItem>
-            <MenuItem
-              onClick={() => handleCopyAsCode('tailwind-all-layers')}
-              disabled={!hasSelection}
-            >
-              Copy Tailwind (all layers)
-            </MenuItem>
-            <MenuItem onClick={() => handleCopyAsCode('swiftui')} disabled={!hasSelection}>
-              Copy SwiftUI
-            </MenuItem>
-            <MenuItem onClick={() => handleCopyAsCode('compose')} disabled={!hasSelection}>
-              Copy Compose
-            </MenuItem>
-            <MenuSeparator />
-            <MenuItem
-              onClick={() => {
-                const allShapes = getAllShapes(ydoc);
-                useEditorStore.getState().setSelectedIds(allShapes.map((s) => s.id));
-                onClose();
-              }}
-              shortcut={`${mod}A`}
-            >
-              Select all
-            </MenuItem>
-          </div>
-        </div>
-      );
-    }
 
     return (
       <div ref={ref}>

--- a/apps/web/src/pages/editor/components/canvas.tsx
+++ b/apps/web/src/pages/editor/components/canvas.tsx
@@ -136,7 +136,6 @@ export function Canvas({
   });
   const { isDragging } = useFileDrop({ ydoc, canvasRef });
   const activeTool = useEditorStore((s) => s.activeTool);
-  const devMode = useEditorStore((s) => s.devMode);
   const activePageId = useEditorStore((s) => s.activePageId);
   const commentsVisible = useEditorStore((s) => s.commentsVisible);
   const activeCommentId = useEditorStore((s) => s.activeCommentId);
@@ -321,8 +320,6 @@ export function Canvas({
         state.setSelectedIds([deeperTargetId]);
         return;
       }
-
-      if (state.devMode) return;
 
       if (targetShape.type === 'text') {
         state.setSelectedIds([targetShape.id]);
@@ -623,7 +620,7 @@ export function Canvas({
     };
   }, [hasOpenCommentPanel, canvasRef]);
 
-  const cursor = devMode && !isPanning ? 'default' : getCursorForTool(activeTool, isPanning);
+  const cursor = getCursorForTool(activeTool, isPanning);
 
   return (
     <div

--- a/apps/web/src/pages/editor/components/editor-toolbar.tsx
+++ b/apps/web/src/pages/editor/components/editor-toolbar.tsx
@@ -15,7 +15,6 @@ import {
   MoveRight,
   MessageCircle,
   ChevronDown,
-  Code2,
 } from 'lucide-react';
 import { Toggle } from '@/components/ui/toggle';
 import { Separator } from '@/components/ui/separator';
@@ -170,60 +169,9 @@ const PEN_TOOLS: ToolOption[] = [
   },
 ];
 
-function DevModeToggle() {
-  const devMode = useEditorStore((s) => s.devMode);
-
+function Tools() {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Toggle
-          size="sm"
-          pressed={devMode}
-          onPressedChange={() => {
-            const store = useEditorStore.getState();
-            store.setDevMode(!store.devMode);
-            store.setRightPanelOpen(true);
-          }}
-          aria-label="Dev Mode"
-          className="h-8 w-8 p-0"
-        >
-          <Code2 className="h-4 w-4" />
-        </Toggle>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="flex items-center gap-2">
-        <span>Dev Mode</span>
-        <kbd className="bg-muted/20 rounded px-1.5 py-0.5 font-mono text-[10px]">⇧D</kbd>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-export function EditorToolbar() {
-  const devMode = useEditorStore((s) => s.devMode);
-
-  if (devMode) {
-    return (
-      <div className="bg-background flex items-center gap-1 rounded-lg border p-1 shadow-sm">
-        <ToolButton
-          tool="move"
-          icon={<MousePointer2 className="h-4 w-4" />}
-          label="Move"
-          shortcut="V"
-        />
-        <ToolButton
-          tool="comment"
-          icon={<MessageCircle className="h-4 w-4" />}
-          label="Comment"
-          shortcut="C"
-        />
-        <Separator orientation="vertical" className="mx-1 h-full" />
-        <DevModeToggle />
-      </div>
-    );
-  }
-
-  return (
-    <div className="bg-background flex items-center gap-1 rounded-lg border p-1 shadow-sm">
+    <>
       <ToolButton
         tool="move"
         icon={<MousePointer2 className="h-4 w-4" />}
@@ -243,8 +191,14 @@ export function EditorToolbar() {
       <Separator orientation="vertical" className="mx-1 h-full" />
       <ToolButton tool="text" icon={<Type className="h-4 w-4" />} label="Text" shortcut="T" />
       <ToolGroup options={PEN_TOOLS} />
-      <Separator orientation="vertical" className="mx-1 h-full" />
-      <DevModeToggle />
+    </>
+  );
+}
+
+export function EditorToolbar() {
+  return (
+    <div className="bg-background flex items-center gap-1 rounded-lg border p-1 shadow-sm">
+      <Tools />
     </div>
   );
 }

--- a/apps/web/src/pages/editor/components/right-panel.tsx
+++ b/apps/web/src/pages/editor/components/right-panel.tsx
@@ -39,7 +39,8 @@ export function RightPanel({ ydoc, draftId }: RightPanelProps) {
   const selectedIds = useEditorStore((s) => s.selectedIds);
   const activePageId = useEditorStore((s) => s.activePageId);
   const rightPanelOpen = useEditorStore((s) => s.rightPanelOpen);
-  const devMode = useEditorStore((s) => s.devMode);
+  const rightPanelView = useEditorStore((s) => s.rightPanelView);
+  const setRightPanelView = useEditorStore((s) => s.setRightPanelView);
   const versionHistoryOpen = useEditorStore((s) => s.versionHistoryOpen);
   const [selectedShape, setSelectedShape] = useState<Shape | null>(null);
   const [instanceLabel, setInstanceLabel] = useState<string | null>(null);
@@ -177,69 +178,96 @@ export function RightPanel({ ydoc, draftId }: RightPanelProps) {
     );
   }
 
-  if (devMode) {
-    return <DevModePanel ydoc={ydoc} />;
-  }
-
   const sections = selectedShape ? getSectionsForShape(selectedShape.type) : [];
 
   return (
-    <div className="flex h-full w-60 shrink-0 flex-col border-l">
+    <div className="flex h-full w-72 shrink-0 flex-col border-l">
       <ZoomControls ydoc={ydoc} />
-      <div className="flex-1 overflow-auto">
-        {!selectedShape && !multiSelected && (
-          <RightPanelCanvas
-            ydoc={ydoc}
-            pageBgColor={pageBgColor}
-            canvasShape={canvasShape}
-            shapeScope={shapeScope}
-            onPageBgColorChange={handlePageBgColorChange}
-          />
-        )}
-        {!selectedShape && multiSelected && (
-          <RightPanelMultiSelect
-            ydoc={ydoc}
-            selectedShapes={selectedShapes}
-            shapeScope={shapeScope}
-            onAlign={handleAlign}
-            onDistribute={handleDistribute}
-            onBatchUpdate={handleBatchUpdate}
-          />
-        )}
-        {selectedShape && (
-          <div>
-            {instanceLabel && (
-              <div className="border-b px-3 py-2">
-                <p className="text-muted-foreground text-[11px] uppercase tracking-wide">
-                  Instance
-                </p>
-                <p className="text-xs font-medium">of {instanceLabel}</p>
-              </div>
-            )}
-            {sections.map((Section, index) => (
-              <div key={Section.name || index} className="border-b px-3 py-3">
-                <Section
-                  ydoc={ydoc}
-                  shape={selectedShape}
-                  shapeScope={shapeScope}
-                  onUpdate={handleUpdate}
-                />
-              </div>
-            ))}
-          </div>
-        )}
+      <div className="flex items-center gap-1 border-b px-3 py-1.5">
+        <PanelViewTab
+          active={rightPanelView === 'properties'}
+          onClick={() => setRightPanelView('properties')}
+        >
+          Properties
+        </PanelViewTab>
+        <PanelViewTab
+          active={rightPanelView === 'inspect'}
+          onClick={() => setRightPanelView('inspect')}
+        >
+          Inspect
+        </PanelViewTab>
       </div>
+      {rightPanelView === 'inspect' ? (
+        <div className="min-h-0 flex-1">
+          <InspectPanel ydoc={ydoc} />
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto">
+          {!selectedShape && !multiSelected && (
+            <RightPanelCanvas
+              ydoc={ydoc}
+              pageBgColor={pageBgColor}
+              canvasShape={canvasShape}
+              shapeScope={shapeScope}
+              onPageBgColorChange={handlePageBgColorChange}
+            />
+          )}
+          {!selectedShape && multiSelected && (
+            <RightPanelMultiSelect
+              ydoc={ydoc}
+              selectedShapes={selectedShapes}
+              shapeScope={shapeScope}
+              onAlign={handleAlign}
+              onDistribute={handleDistribute}
+              onBatchUpdate={handleBatchUpdate}
+            />
+          )}
+          {selectedShape && (
+            <div>
+              {instanceLabel && (
+                <div className="border-b px-3 py-2">
+                  <p className="text-muted-foreground text-[11px] uppercase tracking-wide">
+                    Instance
+                  </p>
+                  <p className="text-xs font-medium">of {instanceLabel}</p>
+                </div>
+              )}
+              {sections.map((Section, index) => (
+                <div key={Section.name || index} className="border-b px-3 py-3">
+                  <Section
+                    ydoc={ydoc}
+                    shape={selectedShape}
+                    shapeScope={shapeScope}
+                    onUpdate={handleUpdate}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
-function DevModePanel({ ydoc }: { ydoc: Y.Doc }) {
+function PanelViewTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="flex h-full w-72 shrink-0 flex-col border-l">
-      <ZoomControls ydoc={ydoc} />
-      <div className="min-h-0 flex-1">
-        <InspectPanel ydoc={ydoc} />
-      </div>
-    </div>
+    <button
+      type="button"
+      className={`rounded px-2 py-1 text-[11px] font-medium transition-colors ${
+        active ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:text-foreground'
+      }`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
   );
 }

--- a/apps/web/src/pages/editor/hooks/use-tool.ts
+++ b/apps/web/src/pages/editor/hooks/use-tool.ts
@@ -5,8 +5,7 @@ import { screenToCanvas } from '@draftila/engine/camera';
 import { getTool, getMoveTool } from '@draftila/engine/tools/tool-manager';
 import type { ToolContext } from '@draftila/engine/tools/base-tool';
 import type { HandTool } from '@draftila/engine/tools/hand-tool';
-import { hitTestPoint } from '@draftila/engine/hit-test';
-import { getAllShapes, resolveGroupTarget, observeShapes } from '@draftila/engine/scene-graph';
+import { getAllShapes, observeShapes } from '@draftila/engine/scene-graph';
 import { SpatialIndex } from '@draftila/engine/spatial-index';
 import { useEditorStore } from '@/stores/editor-store';
 
@@ -45,22 +44,6 @@ function buildContext(
     ctrlKey: e.ctrlKey,
     button: e.button ?? 0,
   };
-}
-
-function devModeHitTest(
-  ctx: ToolContext,
-  shapes: Shape[],
-  spatialIndex: SpatialIndex,
-): string | null {
-  const hit = hitTestPoint(
-    ctx.canvasPoint.x,
-    ctx.canvasPoint.y,
-    shapes,
-    spatialIndex,
-    ctx.camera.zoom,
-  );
-  if (!hit) return null;
-  return resolveGroupTarget(ctx.ydoc, hit.id, useEditorStore.getState().enteredGroupId);
 }
 
 export function useTool({ ydoc, canvasRef, onActiveInteraction }: UseToolOptions) {
@@ -113,26 +96,6 @@ export function useTool({ ydoc, canvasRef, onActiveInteraction }: UseToolOptions
       }
 
       const activeTool = useEditorStore.getState().activeTool;
-
-      if (useEditorStore.getState().devMode && activeTool !== 'comment') {
-        const targetId = devModeHitTest(
-          ctx,
-          cachedShapesRef.current,
-          cachedSpatialIndexRef.current,
-        );
-        const store = useEditorStore.getState();
-        if (targetId) {
-          if (ctx.shiftKey) {
-            store.toggleSelection(targetId);
-          } else {
-            store.setSelectedIds([targetId]);
-          }
-        } else if (!ctx.shiftKey) {
-          store.clearSelection();
-        }
-        return;
-      }
-
       const tool = getTool(activeTool);
       tool.onPointerDown(ctx);
     },
@@ -162,17 +125,6 @@ export function useTool({ ydoc, canvasRef, onActiveInteraction }: UseToolOptions
       }
 
       const activeTool = useEditorStore.getState().activeTool;
-
-      if (useEditorStore.getState().devMode && activeTool !== 'comment') {
-        const targetId = devModeHitTest(
-          ctx,
-          cachedShapesRef.current,
-          cachedSpatialIndexRef.current,
-        );
-        useEditorStore.getState().setHoveredId(targetId);
-        return;
-      }
-
       const tool = getTool(activeTool);
       tool.onPointerMove(ctx);
     },
@@ -212,11 +164,6 @@ export function useTool({ ydoc, canvasRef, onActiveInteraction }: UseToolOptions
       }
 
       const activeTool = useEditorStore.getState().activeTool;
-
-      if (useEditorStore.getState().devMode && activeTool !== 'comment') {
-        return;
-      }
-
       const tool = getTool(activeTool);
       tool.onPointerUp(ctx);
     },

--- a/apps/web/src/pages/editor/lib/keyboard/handle-clipboard.ts
+++ b/apps/web/src/pages/editor/lib/keyboard/handle-clipboard.ts
@@ -11,16 +11,6 @@ export function handleClipboardKeyDown(e: KeyboardEvent, ydoc: Y.Doc): boolean {
   const key = e.key.toLowerCase();
   const code = e.code;
 
-  if (useEditorStore.getState().devMode) {
-    if (isMod && key === 'c') {
-      e.preventDefault();
-      const { selectedIds } = useEditorStore.getState();
-      if (selectedIds.length > 0) copyShapes(ydoc, selectedIds);
-      return true;
-    }
-    return false;
-  }
-
   if (isMod && e.altKey && code === 'KeyC') {
     e.preventDefault();
     const { selectedIds } = useEditorStore.getState();

--- a/apps/web/src/pages/editor/lib/keyboard/handle-shapes.ts
+++ b/apps/web/src/pages/editor/lib/keyboard/handle-shapes.ts
@@ -47,36 +47,6 @@ export function handleShapeKeyDown(e: KeyboardEvent, ydoc: Y.Doc): boolean {
   const key = e.key.toLowerCase();
   const code = e.code;
 
-  if (useEditorStore.getState().devMode) {
-    if (key === 'escape') {
-      e.preventDefault();
-      const { enteredGroupId, setEnteredGroupId, setSelectedIds } = useEditorStore.getState();
-      if (enteredGroupId) {
-        const groupShape = getShape(ydoc, enteredGroupId);
-        const parentGroupId = groupShape?.parentId ?? null;
-        const parentShape = parentGroupId ? getShape(ydoc, parentGroupId) : null;
-        const nextEnteredId = parentShape?.type === 'group' ? parentGroupId : null;
-        setEnteredGroupId(nextEnteredId);
-        setSelectedIds([enteredGroupId]);
-        return true;
-      }
-      useEditorStore.getState().clearSelection();
-      return true;
-    }
-    if (isMod && key === 'a') {
-      e.preventDefault();
-      const allShapes = getAllShapes(ydoc);
-      useEditorStore.getState().setSelectedIds(allShapes.map((s) => s.id));
-      return true;
-    }
-    if (!isMod && code === 'Tab') {
-      e.preventDefault();
-      cycleSelection(ydoc, e.shiftKey);
-      return true;
-    }
-    return false;
-  }
-
   if (!isMod && e.shiftKey && code === 'KeyR') {
     e.preventDefault();
     const { rulersVisible, setRulersVisible, setGuidesVisible } = useEditorStore.getState();

--- a/apps/web/src/pages/editor/lib/keyboard/handle-tools.ts
+++ b/apps/web/src/pages/editor/lib/keyboard/handle-tools.ts
@@ -89,22 +89,10 @@ export function handleToolKeyDown(e: KeyboardEvent, ydoc: Y.Doc): boolean {
   if (!isMod && e.shiftKey && key === 'd') {
     e.preventDefault();
     const store = useEditorStore.getState();
-    store.setDevMode(!store.devMode);
+    const nextView = store.rightPanelView === 'inspect' ? 'properties' : 'inspect';
+    store.setRightPanelView(nextView);
+    store.setRightPanelOpen(true);
     return true;
-  }
-
-  if (useEditorStore.getState().devMode) {
-    if (!isMod && key === 'c') {
-      e.preventDefault();
-      useEditorStore.getState().setActiveTool('comment');
-      return true;
-    }
-    if (!isMod && key === 'v') {
-      e.preventDefault();
-      useEditorStore.getState().setActiveTool('move');
-      return true;
-    }
-    return false;
   }
 
   if (!isMod && key === 'p') {

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -25,7 +25,7 @@ interface EditorState {
   commentsVisible: boolean;
   activeCommentId: string | null;
   aiActiveFrameIds: Set<string>;
-  devMode: boolean;
+  rightPanelView: 'properties' | 'inspect';
   inspectTab: 'list' | 'code';
   versionHistoryOpen: boolean;
   previewSnapshotId: string | null;
@@ -59,7 +59,7 @@ interface EditorState {
   setCommentsVisible: (visible: boolean) => void;
   setActiveCommentId: (id: string | null) => void;
   setAiActiveFrameIds: (ids: Set<string>) => void;
-  setDevMode: (on: boolean) => void;
+  setRightPanelView: (view: 'properties' | 'inspect') => void;
   setInspectTab: (tab: 'list' | 'code') => void;
   setVersionHistoryOpen: (open: boolean) => void;
   enterPreviewMode: (snapshotId: string, ydoc: Y.Doc) => void;
@@ -89,7 +89,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   commentsVisible: localStorage.getItem('draftila:commentsVisible') !== 'false',
   activeCommentId: null,
   aiActiveFrameIds: new Set(),
-  devMode: false,
+  rightPanelView: 'properties',
   inspectTab: 'list',
   versionHistoryOpen: false,
   previewSnapshotId: null,
@@ -185,20 +185,11 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
   setAiActiveFrameIds: (ids) => set({ aiActiveFrameIds: ids }),
 
-  setDevMode: (on) =>
-    set((state) => ({
-      devMode: on,
-      ...(on ? { activeTool: 'move' as const, editingTextId: null } : {}),
-      ...(on && state.versionHistoryOpen ? { versionHistoryOpen: false } : {}),
-    })),
+  setRightPanelView: (view) => set({ rightPanelView: view }),
 
   setInspectTab: (tab) => set({ inspectTab: tab }),
 
-  setVersionHistoryOpen: (open) =>
-    set((state) => ({
-      versionHistoryOpen: open,
-      ...(open && state.devMode ? { devMode: false } : {}),
-    })),
+  setVersionHistoryOpen: (open) => set({ versionHistoryOpen: open }),
 
   enterPreviewMode: (snapshotId, ydoc) =>
     set({


### PR DESCRIPTION
- Remove dev-mode-specific editor behavior from canvas, toolbar, and keyboard handlers.
- Add a right panel view switcher for Properties and Inspect modes.
- Keep inspect tooling available via the dedicated panel tab and Shift+D shortcut.