### PR TITLE
Fix gradient scaling and fill opacity behavior

### DIFF
--- a/packages/engine/src/codegen/compose-generator.ts
+++ b/packages/engine/src/codegen/compose-generator.ts
@@ -96,7 +96,7 @@ function escapeKotlinStringLiteral(value: string): string {
     .replace(/\t/g, '\\t');
 }
 
-function fillToComposeBrush(fill: Fill): string | null {
+function fillToComposeBrush(fill: Fill, width = 0, height = 0): string | null {
   if (!fill.gradient) return null;
 
   const gradient = fill.gradient;
@@ -114,7 +114,7 @@ function fillToComposeBrush(fill: Fill): string | null {
 
   const cx = roundTo(gradient.cx ?? 0.5, 3);
   const cy = roundTo(gradient.cy ?? 0.5, 3);
-  const r = roundTo((gradient.r ?? 0.5) * 100, 1);
+  const r = roundTo((gradient.r ?? 0.5) * Math.max(width, height), 1);
   return `Brush.radialGradient(colors = listOf(${colors}), center = Offset(${cx}f, ${cy}f), radius = ${r}f)`;
 }
 
@@ -177,7 +177,7 @@ function buildModifierChain(shape: Shape, extraParts: string[]): string {
 
   const fills = 'fills' in shape ? getVisibleFills(shape.fills as Fill[]) : [];
   for (const fill of fills) {
-    const brush = fillToComposeBrush(fill);
+    const brush = fillToComposeBrush(fill, shape.width, shape.height);
     if (brush) {
       parts.push(`background(${brush})`);
     } else {
@@ -266,7 +266,7 @@ function ellipseToCompose(shape: EllipseShape): string {
   const fills = getVisibleFills(shape.fills);
   if (fills.length > 0) {
     const fill = fills[0]!;
-    const brush = fillToComposeBrush(fill);
+    const brush = fillToComposeBrush(fill, shape.width, shape.height);
     if (brush) {
       parts.push(`background(${brush})`);
     } else {
@@ -326,7 +326,7 @@ function frameToCompose(shape: FrameShape, children: ShapeTreeNode[]): string {
 
   const fills = getVisibleFills(shape.fills);
   for (const fill of fills) {
-    const brush = fillToComposeBrush(fill);
+    const brush = fillToComposeBrush(fill, shape.width, shape.height);
     if (brush) {
       modifierParts.push(`background(${brush})`);
     } else {

--- a/packages/engine/src/codegen/swiftui-generator.ts
+++ b/packages/engine/src/codegen/swiftui-generator.ts
@@ -116,15 +116,20 @@ function escapeSwiftStringLiteral(value: string): string {
     .replace(/\t/g, '\\t');
 }
 
-function fillToSwiftUI(fill: Fill): string {
+function fillToSwiftUI(fill: Fill, width = 0, height = 0): string {
   if (fill.gradient) {
-    return gradientToSwiftUI(fill.gradient, fill.opacity);
+    return gradientToSwiftUI(fill.gradient, fill.opacity, width, height);
   }
   const rgba = hexToRgba(fill.color, fill.opacity);
   return rgbaToSwiftUIColor(rgba.r, rgba.g, rgba.b, rgba.a);
 }
 
-function gradientToSwiftUI(gradient: NonNullable<Fill['gradient']>, opacity: number): string {
+function gradientToSwiftUI(
+  gradient: NonNullable<Fill['gradient']>,
+  opacity: number,
+  width = 0,
+  height = 0,
+): string {
   const colors = gradient.stops
     .map((s) => {
       const rgba = hexToRgba(s.color, opacity);
@@ -138,7 +143,8 @@ function gradientToSwiftUI(gradient: NonNullable<Fill['gradient']>, opacity: num
     return `LinearGradient(colors: [${colors}], startPoint: ${start}, endPoint: ${end})`;
   }
 
-  return `RadialGradient(colors: [${colors}], center: .center, startRadius: 0, endRadius: ${roundTo((gradient.r ?? 0.5) * 100, 1)})`;
+  const endRadius = (gradient.r ?? 0.5) * Math.max(width, height);
+  return `RadialGradient(colors: [${colors}], center: .center, startRadius: 0, endRadius: ${roundTo(endRadius, 1)})`;
 }
 
 function angleToSwiftUIPoints(angle: number): { start: string; end: string } {
@@ -175,7 +181,7 @@ function buildModifiers(shape: Shape, extras: string[]): string[] {
 
   const fills = 'fills' in shape ? getVisibleFills(shape.fills as Fill[]) : [];
   for (const fill of fills) {
-    modifiers.push(`.background(${fillToSwiftUI(fill)})`);
+    modifiers.push(`.background(${fillToSwiftUI(fill, shape.width, shape.height)})`);
   }
 
   const path = shapePath(shape);
@@ -284,9 +290,9 @@ function buildModifiersWithoutClipShape(shape: Shape): string[] {
 
   const fills = 'fills' in shape ? getVisibleFills(shape.fills as Fill[]) : [];
   if (fills.length > 0) {
-    modifiers.push(`.fill(${fillToSwiftUI(fills[0]!)})`);
+    modifiers.push(`.fill(${fillToSwiftUI(fills[0]!, shape.width, shape.height)})`);
     for (let i = 1; i < fills.length; i++) {
-      modifiers.push(`.background(${fillToSwiftUI(fills[i]!)})`);
+      modifiers.push(`.background(${fillToSwiftUI(fills[i]!, shape.width, shape.height)})`);
     }
   }
 
@@ -366,7 +372,7 @@ function frameToSwiftUI(shape: FrameShape, children: ShapeTreeNode[]): string {
 
   const fills = getVisibleFills(shape.fills);
   for (const fill of fills) {
-    modifiers.push(`.background(${fillToSwiftUI(fill)})`);
+    modifiers.push(`.background(${fillToSwiftUI(fill, shape.width, shape.height)})`);
   }
 
   const path = shapePath(shape);
@@ -508,7 +514,9 @@ function textToSwiftUI(shape: TextShape): string {
   if (fills.length > 0) {
     const fill = fills[0]!;
     if (fill.gradient) {
-      modifiers.push(`.foregroundStyle(${gradientToSwiftUI(fill.gradient, fill.opacity)})`);
+      modifiers.push(
+        `.foregroundStyle(${gradientToSwiftUI(fill.gradient, fill.opacity, shape.width, shape.height)})`,
+      );
     } else {
       const rgba = hexToRgba(fill.color, fill.opacity);
       modifiers.push(`.foregroundColor(${rgbaToSwiftUIColor(rgba.r, rgba.g, rgba.b, rgba.a)})`);

--- a/packages/engine/src/renderer/style-engine.ts
+++ b/packages/engine/src/renderer/style-engine.ts
@@ -170,7 +170,7 @@ export class StyleEngine {
 
       const align = stroke.align ?? 'inside';
 
-      if ((align === 'inside' || (align === 'center' && closed)) && closed) {
+      if (align === 'inside' && closed) {
         ctx.save();
         ctx.clip(path);
         ctx.lineWidth = stroke.width * 2;
@@ -243,13 +243,9 @@ export class StyleEngine {
           ctx.restore();
         } else {
           ctx.fillStyle = this.getFillStyle(fill, width, height);
-          if (!fill.gradient) {
-            ctx.globalAlpha *= fill.opacity;
-          }
+          ctx.globalAlpha *= fill.opacity;
           ctx.fill();
-          if (!fill.gradient) {
-            ctx.globalAlpha = style.opacity;
-          }
+          ctx.globalAlpha = style.opacity;
         }
         continue;
       }


### PR DESCRIPTION
- Scale Compose and SwiftUI radial gradients using shape dimensions instead of fixed values.
- Pass shape width/height through fill and gradient helpers for consistent exported output.
- Adjust canvas style engine fill opacity handling and inside-stroke clipping behavior.