### PR TITLE
Fix selection bounds and duplicate behavior

### DIFF
--- a/apps/web/src/pages/editor/components/canvas-context-menu.tsx
+++ b/apps/web/src/pages/editor/components/canvas-context-menu.tsx
@@ -19,7 +19,6 @@ import {
   opBooleanOperation,
   opCutShapes,
   opPasteShapes,
-  opDuplicateShapesInPlace,
   opPasteStyle,
 } from '@draftila/engine/operations';
 import { exportToSvg, exportToPng } from '@draftila/engine/export';
@@ -189,8 +188,8 @@ export const CanvasContextMenu = forwardRef<HTMLDivElement, CanvasContextMenuPro
 
     const handleDuplicate = useCallback(() => {
       if (hasSelection) {
-        const idMap = opDuplicateShapesInPlace(ydoc, selectedIds);
-        const newIds = [...idMap.values()];
+        copyShapes(ydoc, selectedIds);
+        const newIds = opPasteShapes(ydoc, { selectedIds });
         useEditorStore.getState().setSelectedIds(newIds);
       }
       onClose();

--- a/apps/web/src/pages/editor/lib/fit-camera.ts
+++ b/apps/web/src/pages/editor/lib/fit-camera.ts
@@ -1,6 +1,9 @@
 import type * as Y from 'yjs';
 import { getAllShapes } from '@draftila/engine/scene-graph';
+import { MIN_ZOOM } from '@draftila/engine/camera';
 import { useEditorStore } from '@/stores/editor-store';
+
+const FIT_MAX_ZOOM = 64;
 
 interface Bounds {
   minX: number;
@@ -40,8 +43,8 @@ export function fitCameraToBounds(bounds: Bounds, viewport: DOMRect, padding: nu
   const availableWidth = Math.max(1, viewport.width - padding * 2);
   const availableHeight = Math.max(1, viewport.height - padding * 2);
   const zoom = Math.min(
-    64,
-    Math.max(0.02, Math.min(availableWidth / contentWidth, availableHeight / contentHeight)),
+    FIT_MAX_ZOOM,
+    Math.max(MIN_ZOOM, Math.min(availableWidth / contentWidth, availableHeight / contentHeight)),
   );
 
   const centerX = (bounds.minX + bounds.maxX) / 2;

--- a/packages/engine/src/history.ts
+++ b/packages/engine/src/history.ts
@@ -10,7 +10,7 @@ export function initUndoManager(ydoc: Y.Doc): Y.UndoManager {
   const guides = getActivePageGuidesArray(ydoc);
 
   undoManager = new Y.UndoManager([shapes, zOrder, guides], {
-    captureTimeout: 300,
+    captureTimeout: 500,
   });
 
   return undoManager;

--- a/packages/engine/src/selection-bounds.ts
+++ b/packages/engine/src/selection-bounds.ts
@@ -120,10 +120,27 @@ export function getSelectionBounds(shapes: Shape[]): SelectionBounds | null {
   let maxY = -Infinity;
 
   for (const shape of shapes) {
-    minX = Math.min(minX, shape.x);
-    minY = Math.min(minY, shape.y);
-    maxX = Math.max(maxX, shape.x + shape.width);
-    maxY = Math.max(maxY, shape.y + shape.height);
+    if (shape.rotation !== 0) {
+      const cx = shape.x + shape.width / 2;
+      const cy = shape.y + shape.height / 2;
+      const corners = [
+        rotatePoint(shape.x, shape.y, cx, cy, shape.rotation),
+        rotatePoint(shape.x + shape.width, shape.y, cx, cy, shape.rotation),
+        rotatePoint(shape.x + shape.width, shape.y + shape.height, cx, cy, shape.rotation),
+        rotatePoint(shape.x, shape.y + shape.height, cx, cy, shape.rotation),
+      ];
+      for (const c of corners) {
+        minX = Math.min(minX, c.x);
+        minY = Math.min(minY, c.y);
+        maxX = Math.max(maxX, c.x);
+        maxY = Math.max(maxY, c.y);
+      }
+    } else {
+      minX = Math.min(minX, shape.x);
+      minY = Math.min(minY, shape.y);
+      maxX = Math.max(maxX, shape.x + shape.width);
+      maxY = Math.max(maxY, shape.y + shape.height);
+    }
   }
 
   const x = minX;

--- a/packages/engine/tests/selection-bounds.test.ts
+++ b/packages/engine/tests/selection-bounds.test.ts
@@ -129,7 +129,22 @@ describe('getSelectionBounds', () => {
     ];
     const bounds = getSelectionBounds(shapes)!;
     expect(bounds.rotation).toBe(0);
-    expect(bounds.x).toBe(0);
-    expect(bounds.width).toBe(150);
+    expect(bounds.width).toBeGreaterThan(150);
+  });
+
+  test('multi-selection accounts for rotated shape corners', () => {
+    const unrotated = [
+      makeShape({ id: 'a', x: 0, y: 0, width: 100, height: 10, rotation: 0 }),
+      makeShape({ id: 'b', x: 200, y: 200, width: 20, height: 20, rotation: 0 }),
+    ];
+    const boundsUnrotated = getSelectionBounds(unrotated)!;
+
+    const rotated = [
+      makeShape({ id: 'a', x: 0, y: 0, width: 100, height: 10, rotation: 45 }),
+      makeShape({ id: 'b', x: 200, y: 200, width: 20, height: 20, rotation: 0 }),
+    ];
+    const boundsRotated = getSelectionBounds(rotated)!;
+
+    expect(boundsRotated.height).toBeGreaterThan(boundsUnrotated.height);
   });
 });


### PR DESCRIPTION
- Fix multi-selection bounds to include rotated shape corners.
- Update duplicate action to reuse copy/paste flow for selection handling.
- Align fit-camera minimum zoom and increase undo capture window.