### PR TITLE
Fix image rendering in MCP PNG export

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: code-review
+description: Exhaustively review every line in a diff from a fixed point along two independent axes—repository standards and the originating spec—with evidenced findings, explicit coverage, and bounded fix verification.
+---
+
+# Code Review
+
+Review one immutable diff against:
+
+- **Standards** — repository instructions and documented coding standards.
+- **Spec** — the originating issue, PRD, or acceptance criteria.
+
+## Prepare
+
+1. Pin the requested input. Resolve committed endpoints to SHAs; if staged or working-tree changes are included, capture one patch snapshot. Give every reviewer that same immutable diff. Stop on invalid or empty input.
+2. Find the spec from commit references, a user-provided path, or matching files under `docs/`, `specs/`, or `.scratch/`. If none exists, mark the Spec axis unavailable.
+3. Find applicable repository instructions and standards such as `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `CODING_STANDARDS.md`.
+4. Inventory the complete diff: files, hunks, additions, deletions, renames, and binary files. Never rely on one possibly truncated diff output.
+
+## Review
+
+- Inspect every added, changed, and deleted line in every file, including tests, docs, configuration, migrations, lock/generated files, renames, and binaries. Read surrounding code and call sites where needed.
+- Maintain a file-and-hunk checklist against the inventory. Inspect file by file or in smaller batches so output cannot hide lines through truncation. Do not finish with an unchecked line or hunk.
+- Report only issues introduced by the diff. A blocker requires evidence of an acceptance, correctness, security, data-loss, compatibility, or explicit required-standard violation. Style preferences, generic code smells, speculative hardening, optional refactors, and unrelated debt are non-blocking advisories.
+- For findings, provide severity, `file:line`, the violated spec/rule or invariant, a concrete failure scenario, evidence, and the smallest valid fix. Do not report vague possibilities.
+- Return `PASS` or `CHANGES NEEDED`, then blockers, advisories, and coverage totals. `PASS` means zero blockers, not zero possible improvements.
+
+Compare both coverage reports with the inventory. If anything is missing, review only the missing batches before reporting; an incomplete review cannot pass.
+
+## Report
+
+- Present `## Standards` and `## Spec` separately. End with blocker and advisory counts per axis. Do not let advisories change a pass into failure.
+- Also when presenting, each findings should have severity, High, Medium, Low and clarify which ones must be fixed before proceeding.
+- Recommend `FIX BEFORE PROCEEDING`, `CONSIDER FIXING`, or `PROCEED` from the evidenced severity, confidence, and risk, and name the findings that drive the recommendation. The review is read-only: the user decides whether to fix. Ask for that decision and do not edit or dispatch a fixer without explicit approval.
+- Do not report advisories unless user asks for them.
+- Provide a TL;DR section in the end in short in a table
+

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -34,4 +34,3 @@ Compare both coverage reports with the inventory. If anything is missing, review
 - Recommend `FIX BEFORE PROCEEDING`, `CONSIDER FIXING`, or `PROCEED` from the evidenced severity, confidence, and risk, and name the findings that drive the recommendation. The review is read-only: the user decides whether to fix. Ask for that decision and do not edit or dispatch a fixer without explicit approval.
 - Do not report advisories unless user asks for them.
 - Provide a TL;DR section in the end in short in a table
-

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "@prisma/client": "^6.7.0",
     "better-auth": "^1.1.14",
     "hono": "^4.6.14",
+    "image-size": "^2.0.2",
     "jszip": "^3.10.1",
     "lib0": "^0.2.117",
     "linkedom": "^0.18.12",

--- a/apps/api/src/modules/mcp/image-loader.ts
+++ b/apps/api/src/modules/mcp/image-loader.ts
@@ -1,0 +1,122 @@
+import { lookup } from 'node:dns/promises';
+import { loadImage } from '@napi-rs/canvas';
+
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_REDIRECTS = 3;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function toIpv4Octets(address: string): number[] | null {
+  const mapped = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address;
+  const parts = mapped.split('.');
+  if (parts.length !== 4) return null;
+  return parts.map((part) => Number(part));
+}
+
+function isBlockedIpv4(octets: number[]): boolean {
+  const [a = 0, b = 0] = octets;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isBlockedAddress(address: string): boolean {
+  const octets = toIpv4Octets(address);
+  if (octets) return isBlockedIpv4(octets);
+
+  const normalized = address.toLowerCase().split('%')[0] ?? '';
+  if (normalized === '::' || normalized === '::1') return true;
+  if (normalized.startsWith('fe8') || normalized.startsWith('fe9')) return true;
+  if (normalized.startsWith('fea') || normalized.startsWith('feb')) return true;
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+  return false;
+}
+
+async function assertPublicUrl(url: URL): Promise<void> {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported image protocol: ${url.protocol}`);
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  const addresses = await lookup(hostname, { all: true });
+  if (addresses.some(({ address }) => isBlockedAddress(address))) {
+    throw new Error(`Blocked image host: ${hostname}`);
+  }
+}
+
+async function readCappedBody(response: Response): Promise<Buffer> {
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
+    throw new Error('Image exceeds the maximum allowed size');
+  }
+
+  const body = response.body;
+  if (!body) throw new Error('Image response has no body');
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_IMAGE_BYTES) {
+      await reader.cancel();
+      throw new Error('Image exceeds the maximum allowed size');
+    }
+    chunks.push(value);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+export function decodeDataUri(src: string): Buffer {
+  const commaIndex = src.indexOf(',');
+  if (commaIndex < 0) throw new Error('Malformed image data URI');
+
+  const meta = src.slice('data:'.length, commaIndex);
+  const payload = src.slice(commaIndex + 1);
+  if (meta.endsWith(';base64')) return Buffer.from(payload, 'base64');
+  return Buffer.from(decodeURIComponent(payload), 'utf-8');
+}
+
+export async function fetchImageBytes(src: string): Promise<Buffer> {
+  let url = new URL(src);
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+    await assertPublicUrl(url);
+
+    const response = await fetch(url, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      headers: { Accept: 'image/*' },
+    });
+
+    const location = response.headers.get('location');
+    if (REDIRECT_STATUSES.has(response.status) && location) {
+      await response.body?.cancel();
+      url = new URL(location, url);
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Image request failed with status ${response.status}`);
+    }
+
+    return readCappedBody(response);
+  }
+
+  throw new Error('Too many redirects while loading image');
+}
+
+export async function loadServerImage(src: string): Promise<HTMLImageElement> {
+  const bytes = src.startsWith('data:') ? decodeDataUri(src) : await fetchImageBytes(src);
+  const image = await loadImage(bytes);
+  return image as unknown as HTMLImageElement;
+}

--- a/apps/api/src/modules/mcp/image-loader.ts
+++ b/apps/api/src/modules/mcp/image-loader.ts
@@ -1,10 +1,26 @@
 import { lookup } from 'node:dns/promises';
+import { request as httpRequest } from 'node:http';
+import type { IncomingMessage, RequestOptions } from 'node:http';
+import { request as httpsRequest } from 'node:https';
 import { loadImage } from '@napi-rs/canvas';
+import { imageSize } from 'image-size';
 
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const MAX_IMAGE_PIXELS = 30_000_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_REDIRECTS = 3;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+export interface PinnedAddress {
+  address: string;
+  family: number;
+}
+
+export type ImageRequestSender = (
+  url: URL,
+  address: PinnedAddress,
+  signal: AbortSignal,
+) => Promise<IncomingMessage>;
 
 function toIpv4Octets(address: string): number[] | null {
   const mapped = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address;
@@ -37,43 +53,114 @@ function isBlockedAddress(address: string): boolean {
   return false;
 }
 
-async function assertPublicUrl(url: URL): Promise<void> {
+function stripBrackets(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, '');
+}
+
+async function resolvePublicAddress(url: URL): Promise<PinnedAddress> {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new Error(`Unsupported image protocol: ${url.protocol}`);
   }
 
-  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  const hostname = stripBrackets(url.hostname);
   const addresses = await lookup(hostname, { all: true });
-  if (addresses.some(({ address }) => isBlockedAddress(address))) {
+  const [resolved] = addresses;
+  if (!resolved || addresses.some(({ address }) => isBlockedAddress(address))) {
     throw new Error(`Blocked image host: ${hostname}`);
   }
+
+  return { address: resolved.address, family: resolved.family };
 }
 
-async function readCappedBody(response: Response): Promise<Buffer> {
-  const declaredLength = Number(response.headers.get('content-length'));
+export function requestPinnedImage(
+  url: URL,
+  address: PinnedAddress,
+  signal: AbortSignal,
+): Promise<IncomingMessage> {
+  const send = url.protocol === 'https:' ? httpsRequest : httpRequest;
+  const options: RequestOptions = {
+    protocol: url.protocol,
+    hostname: stripBrackets(url.hostname),
+    port: url.port || undefined,
+    path: `${url.pathname}${url.search}`,
+    headers: { Accept: 'image/*' },
+    signal,
+    agent: false,
+    lookup: (_hostname, lookupOptions, callback) => {
+      if (lookupOptions.all) callback(null, [address]);
+      else callback(null, address.address, address.family);
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const abort = () => reject(new Error('Image request aborted'));
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+
+    signal.addEventListener('abort', abort, { once: true });
+    const request = send(options, (response) => {
+      signal.removeEventListener('abort', abort);
+      resolve(response);
+    });
+    request.on('error', (error) => {
+      signal.removeEventListener('abort', abort);
+      reject(error);
+    });
+    request.end();
+  });
+}
+
+let sendImageRequest: ImageRequestSender = requestPinnedImage;
+
+export function setImageRequestSender(sender: ImageRequestSender) {
+  sendImageRequest = sender;
+}
+
+async function readCappedBody(response: IncomingMessage): Promise<Buffer> {
+  const declaredLength = Number(response.headers['content-length']);
   if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
+    response.destroy();
     throw new Error('Image exceeds the maximum allowed size');
   }
 
-  const body = response.body;
-  if (!body) throw new Error('Image response has no body');
-
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: Buffer[] = [];
   let total = 0;
 
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
+  for await (const chunk of response) {
+    const bytes = chunk as Buffer;
+    total += bytes.byteLength;
     if (total > MAX_IMAGE_BYTES) {
-      await reader.cancel();
+      response.destroy();
       throw new Error('Image exceeds the maximum allowed size');
     }
-    chunks.push(value);
+    chunks.push(bytes);
   }
 
+  if (total === 0) throw new Error('Image response has no body');
+
   return Buffer.concat(chunks);
+}
+
+function largestFramePixels(dimensions: ReturnType<typeof imageSize>): number {
+  return (dimensions.images ?? []).reduce(
+    (largest, frame) => Math.max(largest, frame.width * frame.height),
+    dimensions.width * dimensions.height,
+  );
+}
+
+function assertDecodableSize(bytes: Buffer): void {
+  let dimensions: ReturnType<typeof imageSize>;
+  try {
+    dimensions = imageSize(bytes);
+  } catch {
+    throw new Error('Unsupported or unreadable image format');
+  }
+
+  if (largestFramePixels(dimensions) > MAX_IMAGE_PIXELS) {
+    throw new Error('Image exceeds the maximum allowed pixel count');
+  }
 }
 
 export function decodeDataUri(src: string): Buffer {
@@ -82,31 +169,36 @@ export function decodeDataUri(src: string): Buffer {
 
   const meta = src.slice('data:'.length, commaIndex);
   const payload = src.slice(commaIndex + 1);
-  if (meta.endsWith(';base64')) return Buffer.from(payload, 'base64');
-  return Buffer.from(decodeURIComponent(payload), 'utf-8');
+  const bytes = meta.endsWith(';base64')
+    ? Buffer.from(payload, 'base64')
+    : Buffer.from(decodeURIComponent(payload), 'utf-8');
+
+  if (bytes.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error('Image exceeds the maximum allowed size');
+  }
+
+  return bytes;
 }
 
 export async function fetchImageBytes(src: string): Promise<Buffer> {
+  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
   let url = new URL(src);
 
   for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
-    await assertPublicUrl(url);
+    const address = await resolvePublicAddress(url);
+    const response = await sendImageRequest(url, address, signal);
+    const status = response.statusCode ?? 0;
+    const location = response.headers.location;
 
-    const response = await fetch(url, {
-      redirect: 'manual',
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      headers: { Accept: 'image/*' },
-    });
-
-    const location = response.headers.get('location');
-    if (REDIRECT_STATUSES.has(response.status) && location) {
-      await response.body?.cancel();
+    if (REDIRECT_STATUSES.has(status) && location) {
+      response.resume();
       url = new URL(location, url);
       continue;
     }
 
-    if (!response.ok) {
-      throw new Error(`Image request failed with status ${response.status}`);
+    if (status < 200 || status > 299) {
+      response.destroy();
+      throw new Error(`Image request failed with status ${status}`);
     }
 
     return readCappedBody(response);
@@ -117,6 +209,7 @@ export async function fetchImageBytes(src: string): Promise<Buffer> {
 
 export async function loadServerImage(src: string): Promise<HTMLImageElement> {
   const bytes = src.startsWith('data:') ? decodeDataUri(src) : await fetchImageBytes(src);
+  assertDecodableSize(bytes);
   const image = await loadImage(bytes);
   return image as unknown as HTMLImageElement;
 }

--- a/apps/api/src/modules/mcp/server-rpc.ts
+++ b/apps/api/src/modules/mcp/server-rpc.ts
@@ -6,7 +6,11 @@ import {
   getAllShapes,
   Canvas2DRenderer,
   collectFontFamilies,
+  collectImageSources,
+  preloadImages,
   renderWithClipping,
+  setImageCacheLimit,
+  setImageLoader,
   setTextMeasureEnabled,
 } from '@draftila/engine';
 import type { RpcHandler } from '@draftila/engine/rpc-handlers';
@@ -15,8 +19,13 @@ import { createCanvas, GlobalFonts } from '@napi-rs/canvas';
 import { existsSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import * as collaborationService from '../collaboration/collaboration.service';
+import { loadServerImage } from './image-loader';
+
+const IMAGE_CACHE_LIMIT_BYTES = 128 * 1024 * 1024;
 
 setTextMeasureEnabled(false);
+setImageLoader(loadServerImage);
+setImageCacheLimit(IMAGE_CACHE_LIMIT_BYTES);
 
 const FONT_CACHE_DIR = join(process.cwd(), '.cache', 'fonts');
 const registeredFontVariants = new Set<string>();
@@ -122,6 +131,7 @@ async function serverExportToPng(
   if (shapes.length === 0) throw new Error('No shapes to export');
 
   await ensureServerFontsLoaded(shapes);
+  await preloadImages(collectImageSources(shapes));
 
   let minX = Infinity,
     minY = Infinity,

--- a/apps/api/src/modules/mcp/server-rpc.ts
+++ b/apps/api/src/modules/mcp/server-rpc.ts
@@ -22,6 +22,8 @@ import * as collaborationService from '../collaboration/collaboration.service';
 import { loadServerImage } from './image-loader';
 
 const IMAGE_CACHE_LIMIT_BYTES = 128 * 1024 * 1024;
+const IMAGE_PRELOAD_LIMIT = 200;
+const IMAGE_PRELOAD_TIMEOUT_MS = 30_000;
 
 setTextMeasureEnabled(false);
 setImageLoader(loadServerImage);
@@ -131,7 +133,15 @@ async function serverExportToPng(
   if (shapes.length === 0) throw new Error('No shapes to export');
 
   await ensureServerFontsLoaded(shapes);
-  await preloadImages(collectImageSources(shapes));
+  const preloaded = await preloadImages(collectImageSources(shapes), {
+    limit: IMAGE_PRELOAD_LIMIT,
+    timeoutMs: IMAGE_PRELOAD_TIMEOUT_MS,
+  });
+  if (preloaded.skipped > 0) {
+    console.warn(
+      `export_png skipped ${preloaded.skipped} of ${preloaded.requested} images (limit ${IMAGE_PRELOAD_LIMIT}, timeout ${IMAGE_PRELOAD_TIMEOUT_MS}ms)`,
+    );
+  }
 
   let minX = Infinity,
     minY = Infinity,

--- a/apps/api/tests/modules/mcp-image-loader.test.ts
+++ b/apps/api/tests/modules/mcp-image-loader.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { createServer } from 'node:http';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { deflateSync, crc32 } from 'node:zlib';
 import {
   decodeDataUri,
   fetchImageBytes,
   loadServerImage,
+  requestPinnedImage,
+  setImageRequestSender,
+  type ImageRequestSender,
 } from '../../src/modules/mcp/image-loader';
 
 const PNG_BASE64 =
@@ -12,26 +19,48 @@ const SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"></sv
 const PUBLIC_HOST = 'http://93.184.216.34/image.png';
 const PUBLIC_IPV6_HOST = 'http://[2606:2800:220:1:248:1893:25c8:1946]/image.png';
 
-const originalFetch = globalThis.fetch;
-
-function stubFetch(handler: (url: URL) => Response) {
-  globalThis.fetch = ((input: string | URL | Request) =>
-    Promise.resolve(handler(new URL(String(input))))) as typeof fetch;
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const typed = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(typed) >>> 0);
+  return Buffer.concat([length, typed, checksum]);
 }
 
-function streamOf(chunkCount: number, chunkSize: number): Response {
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      for (let i = 0; i < chunkCount; i++) controller.enqueue(new Uint8Array(chunkSize));
-      controller.close();
-    },
-  });
-  return new Response(stream);
+function grayscalePng(width: number, height: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 0;
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', header),
+    pngChunk('IDAT', deflateSync(Buffer.alloc(height * (1 + width)), { level: 9 })),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+function responseOf(
+  status: number,
+  headers: Record<string, string>,
+  chunks: Uint8Array[],
+): IncomingMessage {
+  const stream = Readable.from(chunks) as unknown as IncomingMessage;
+  stream.statusCode = status;
+  stream.headers = headers;
+  return stream;
+}
+
+function stubSender(handler: (url: URL) => IncomingMessage) {
+  const sender: ImageRequestSender = (url) => Promise.resolve(handler(url));
+  setImageRequestSender(sender);
 }
 
 describe('mcp image loader', () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    setImageRequestSender(requestPinnedImage);
   });
 
   describe('data URIs', () => {
@@ -48,6 +77,13 @@ describe('mcp image loader', () => {
       expect(() => decodeDataUri('data:image/png;base64')).toThrow('Malformed image data URI');
     });
 
+    test('rejects oversized data URI payloads', () => {
+      const oversized = 'A'.repeat(21 * 1024 * 1024);
+      expect(() => decodeDataUri(`data:image/png,${oversized}`)).toThrow(
+        'Image exceeds the maximum allowed size',
+      );
+    });
+
     test('loads a raster image without touching the network', async () => {
       const image = await loadServerImage(`data:image/png;base64,${PNG_BASE64}`);
       expect(image.naturalWidth).toBe(1);
@@ -62,36 +98,62 @@ describe('mcp image loader', () => {
     });
   });
 
+  describe('decode limits', () => {
+    test('rejects a raster image that decodes beyond the pixel budget', async () => {
+      const bomb = grayscalePng(10000, 10000);
+      expect(bomb.byteLength).toBeLessThan(1024 * 1024);
+
+      await expect(
+        loadServerImage(`data:image/png;base64,${bomb.toString('base64')}`),
+      ).rejects.toThrow('Image exceeds the maximum allowed pixel count');
+    });
+
+    test('rejects an svg that rasterises beyond the pixel budget', async () => {
+      const huge = '<svg xmlns="http://www.w3.org/2000/svg" width="60000" height="60000"></svg>';
+      const uri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(huge)}`;
+
+      await expect(loadServerImage(uri)).rejects.toThrow(
+        'Image exceeds the maximum allowed pixel count',
+      );
+    });
+
+    test('rejects payloads whose format cannot be read', async () => {
+      const uri = `data:image/png;base64,${Buffer.from('not an image').toString('base64')}`;
+
+      await expect(loadServerImage(uri)).rejects.toThrow('Unsupported or unreadable image format');
+    });
+  });
+
   describe('remote images', () => {
     test('downloads and decodes a remote image', async () => {
-      stubFetch(() => new Response(PNG_BYTES));
+      stubSender(() => responseOf(200, {}, [PNG_BYTES]));
       const image = await loadServerImage(PUBLIC_HOST);
       expect(image.naturalWidth).toBe(1);
     });
 
     test('allows public IPv6 hosts', async () => {
-      stubFetch(() => new Response(PNG_BYTES));
+      stubSender(() => responseOf(200, {}, [PNG_BYTES]));
       expect(await fetchImageBytes(PUBLIC_IPV6_HOST)).toEqual(PNG_BYTES);
     });
 
     test('follows redirects', async () => {
-      stubFetch((url) =>
+      stubSender((url) =>
         url.pathname === '/image.png'
-          ? new Response('', { status: 302, headers: { location: '/final.png' } })
-          : new Response(PNG_BYTES),
+          ? responseOf(302, { location: '/final.png' }, [])
+          : responseOf(200, {}, [PNG_BYTES]),
       );
 
       expect(await fetchImageBytes(PUBLIC_HOST)).toEqual(PNG_BYTES);
     });
 
     test('rejects redirect loops', async () => {
-      stubFetch(() => new Response('', { status: 302, headers: { location: '/image.png' } }));
+      stubSender(() => responseOf(302, { location: '/image.png' }, []));
 
       await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow('Too many redirects');
     });
 
     test('rejects error responses', async () => {
-      stubFetch(() => new Response('nope', { status: 404 }));
+      stubSender(() => responseOf(404, {}, [Buffer.from('nope')]));
 
       await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow(
         'Image request failed with status 404',
@@ -99,17 +161,14 @@ describe('mcp image loader', () => {
     });
 
     test('rejects responses without a body', async () => {
-      stubFetch(() => new Response(null, { status: 200 }));
+      stubSender(() => responseOf(200, {}, []));
 
       await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow('Image response has no body');
     });
 
     test('rejects responses declaring an oversized body', async () => {
-      stubFetch(
-        () =>
-          new Response(PNG_BYTES, {
-            headers: { 'content-length': String(64 * 1024 * 1024) },
-          }),
+      stubSender(() =>
+        responseOf(200, { 'content-length': String(64 * 1024 * 1024) }, [PNG_BYTES]),
       );
 
       await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow(
@@ -118,7 +177,13 @@ describe('mcp image loader', () => {
     });
 
     test('rejects bodies that stream past the size limit', async () => {
-      stubFetch(() => streamOf(21, 1024 * 1024));
+      stubSender(() =>
+        responseOf(
+          200,
+          {},
+          Array.from({ length: 21 }, () => new Uint8Array(1024 * 1024)),
+        ),
+      );
 
       await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow(
         'Image exceeds the maximum allowed size',
@@ -144,16 +209,69 @@ describe('mcp image loader', () => {
       await expect(fetchImageBytes(url)).rejects.toThrow('Blocked image host');
     });
 
+    test('rejects hosts that do not resolve', async () => {
+      await expect(fetchImageBytes('http://unresolvable.invalid/image.png')).rejects.toThrow();
+    });
+
     test('rejects redirects that point at a private host', async () => {
-      stubFetch(
-        () =>
-          new Response('', {
-            status: 302,
-            headers: { location: 'http://127.0.0.1/image.png' },
-          }),
-      );
+      stubSender(() => responseOf(302, { location: 'http://127.0.0.1/image.png' }, []));
 
       await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow('Blocked image host');
+    });
+  });
+
+  describe('pinned transport', () => {
+    let server: Server;
+    let port = 0;
+
+    beforeAll(async () => {
+      server = createServer((request: IncomingMessage, response: ServerResponse) => {
+        if (request.url === '/image.png') {
+          response.writeHead(200, { 'content-type': 'image/png' });
+          response.end(PNG_BYTES);
+          return;
+        }
+        response.writeHead(404);
+        response.end();
+      });
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+      port = (server.address() as { port: number }).port;
+    });
+
+    afterAll(() => {
+      server.closeAllConnections();
+      server.close();
+    });
+
+    test('connects to the pinned address instead of re-resolving the hostname', async () => {
+      const url = new URL(`http://pinned.invalid:${port}/image.png`);
+      const response = await requestPinnedImage(
+        url,
+        { address: '127.0.0.1', family: 4 },
+        AbortSignal.timeout(5_000),
+      );
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of response) chunks.push(chunk as Buffer);
+
+      expect(response.statusCode).toBe(200);
+      expect(Buffer.concat(chunks)).toEqual(PNG_BYTES);
+    });
+
+    test('surfaces connection failures', async () => {
+      const url = new URL('http://pinned.invalid:1/image.png');
+
+      await expect(
+        requestPinnedImage(url, { address: '127.0.0.1', family: 4 }, AbortSignal.timeout(5_000)),
+      ).rejects.toThrow();
+    });
+
+    test('rejects immediately when the deadline has already passed', async () => {
+      const url = new URL(`http://pinned.invalid:${port}/image.png`);
+
+      await expect(
+        requestPinnedImage(url, { address: '127.0.0.1', family: 4 }, AbortSignal.abort()),
+      ).rejects.toThrow('Image request aborted');
     });
   });
 });

--- a/apps/api/tests/modules/mcp-image-loader.test.ts
+++ b/apps/api/tests/modules/mcp-image-loader.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  decodeDataUri,
+  fetchImageBytes,
+  loadServerImage,
+} from '../../src/modules/mcp/image-loader';
+
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64');
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"></svg>';
+const PUBLIC_HOST = 'http://93.184.216.34/image.png';
+const PUBLIC_IPV6_HOST = 'http://[2606:2800:220:1:248:1893:25c8:1946]/image.png';
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch(handler: (url: URL) => Response) {
+  globalThis.fetch = ((input: string | URL | Request) =>
+    Promise.resolve(handler(new URL(String(input))))) as typeof fetch;
+}
+
+function streamOf(chunkCount: number, chunkSize: number): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < chunkCount; i++) controller.enqueue(new Uint8Array(chunkSize));
+      controller.close();
+    },
+  });
+  return new Response(stream);
+}
+
+describe('mcp image loader', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('data URIs', () => {
+    test('decodes base64 payloads', () => {
+      expect(decodeDataUri(`data:image/png;base64,${PNG_BASE64}`)).toEqual(PNG_BYTES);
+    });
+
+    test('decodes percent-encoded payloads', () => {
+      const uri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(SVG)}`;
+      expect(decodeDataUri(uri).toString('utf-8')).toBe(SVG);
+    });
+
+    test('rejects malformed data URIs', () => {
+      expect(() => decodeDataUri('data:image/png;base64')).toThrow('Malformed image data URI');
+    });
+
+    test('loads a raster image without touching the network', async () => {
+      const image = await loadServerImage(`data:image/png;base64,${PNG_BASE64}`);
+      expect(image.naturalWidth).toBe(1);
+      expect(image.naturalHeight).toBe(1);
+    });
+
+    test('loads a percent-encoded svg data URI', async () => {
+      const uri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(SVG)}`;
+      const image = await loadServerImage(uri);
+      expect(image.naturalWidth).toBe(24);
+      expect(image.naturalHeight).toBe(24);
+    });
+  });
+
+  describe('remote images', () => {
+    test('downloads and decodes a remote image', async () => {
+      stubFetch(() => new Response(PNG_BYTES));
+      const image = await loadServerImage(PUBLIC_HOST);
+      expect(image.naturalWidth).toBe(1);
+    });
+
+    test('allows public IPv6 hosts', async () => {
+      stubFetch(() => new Response(PNG_BYTES));
+      expect(await fetchImageBytes(PUBLIC_IPV6_HOST)).toEqual(PNG_BYTES);
+    });
+
+    test('follows redirects', async () => {
+      stubFetch((url) =>
+        url.pathname === '/image.png'
+          ? new Response('', { status: 302, headers: { location: '/final.png' } })
+          : new Response(PNG_BYTES),
+      );
+
+      expect(await fetchImageBytes(PUBLIC_HOST)).toEqual(PNG_BYTES);
+    });
+
+    test('rejects redirect loops', async () => {
+      stubFetch(() => new Response('', { status: 302, headers: { location: '/image.png' } }));
+
+      await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow('Too many redirects');
+    });
+
+    test('rejects error responses', async () => {
+      stubFetch(() => new Response('nope', { status: 404 }));
+
+      await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow(
+        'Image request failed with status 404',
+      );
+    });
+
+    test('rejects responses without a body', async () => {
+      stubFetch(() => new Response(null, { status: 200 }));
+
+      await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow('Image response has no body');
+    });
+
+    test('rejects responses declaring an oversized body', async () => {
+      stubFetch(
+        () =>
+          new Response(PNG_BYTES, {
+            headers: { 'content-length': String(64 * 1024 * 1024) },
+          }),
+      );
+
+      await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow(
+        'Image exceeds the maximum allowed size',
+      );
+    });
+
+    test('rejects bodies that stream past the size limit', async () => {
+      stubFetch(() => streamOf(21, 1024 * 1024));
+
+      await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow(
+        'Image exceeds the maximum allowed size',
+      );
+    });
+  });
+
+  describe('host restrictions', () => {
+    test('rejects non-http protocols', async () => {
+      await expect(fetchImageBytes('ftp://93.184.216.34/image.png')).rejects.toThrow(
+        'Unsupported image protocol',
+      );
+    });
+
+    test.each([
+      'http://127.0.0.1/image.png',
+      'http://10.0.0.5/image.png',
+      'http://169.254.169.254/latest/meta-data',
+      'http://192.168.1.10/image.png',
+      'http://[::1]/image.png',
+      'http://[fd00::1]/image.png',
+    ])('rejects private host %s', async (url) => {
+      await expect(fetchImageBytes(url)).rejects.toThrow('Blocked image host');
+    });
+
+    test('rejects redirects that point at a private host', async () => {
+      stubFetch(
+        () =>
+          new Response('', {
+            status: 302,
+            headers: { location: 'http://127.0.0.1/image.png' },
+          }),
+      );
+
+      await expect(fetchImageBytes(PUBLIC_HOST)).rejects.toThrow('Blocked image host');
+    });
+  });
+});

--- a/apps/web/src/pages/editor/components/right-panel/sections/fill-section.tsx
+++ b/apps/web/src/pages/editor/components/right-panel/sections/fill-section.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 const CHECKERBOARD = 'repeating-conic-gradient(#808080 0% 25%, transparent 0% 50%) 0 0 / 8px 8px';
+const DEFAULT_FILL_COLOR = '#D9D9D9';
 
 type FillType = 'solid' | 'linear' | 'radial';
 
@@ -81,7 +82,7 @@ export function FillSection({ shape, onUpdate }: PropertySectionProps) {
 
   const addFill = useCallback(() => {
     if (!fills) return;
-    const newFill: Fill = { color: '#D9D9D9', opacity: 1, visible: true };
+    const newFill: Fill = { color: DEFAULT_FILL_COLOR, opacity: 1, visible: true };
     onUpdate({ fills: [...fills, newFill] } as Partial<Shape>);
   }, [fills, onUpdate]);
 
@@ -148,15 +149,16 @@ function FillRow({
 }) {
   const opacityPercent = Math.round(fill.opacity * 100);
   const fillType = getFillType(fill);
+  const solidColor = fill.color ?? DEFAULT_FILL_COLOR;
 
   const handleTypeChange = (newType: FillType) => {
     if (newType === fillType) return;
     if (newType === 'solid') {
-      const baseColor = fill.gradient?.stops[0]?.color ?? fill.color;
+      const baseColor = fill.gradient?.stops[0]?.color ?? solidColor;
       onReplace({ color: baseColor, opacity: fill.opacity, visible: fill.visible });
       return;
     }
-    const gradient = defaultGradient(newType, fill.color);
+    const gradient = defaultGradient(newType, solidColor);
     onReplace({ ...fill, gradient });
   };
 
@@ -165,8 +167,8 @@ function FillRow({
   };
 
   const displayLabel = fill.gradient
-    ? (fill.gradient.stops[0]?.color ?? fill.color).replace('#', '').toUpperCase()
-    : fill.color.replace('#', '').toUpperCase();
+    ? (fill.gradient.stops[0]?.color ?? solidColor).replace('#', '').toUpperCase()
+    : solidColor.replace('#', '').toUpperCase();
 
   const editorContent = (
     <button
@@ -187,14 +189,14 @@ function FillRow({
             <div
               className="absolute inset-0"
               style={{
-                backgroundColor: fill.color,
+                backgroundColor: solidColor,
                 opacity: fill.opacity,
               }}
             />
             <div
               className="absolute inset-0"
               style={{
-                backgroundColor: fill.color,
+                backgroundColor: solidColor,
                 clipPath: 'polygon(0 0, 50% 0, 50% 100%, 0 100%)',
               }}
             />
@@ -218,7 +220,7 @@ function FillRow({
         </GradientEditor>
       ) : (
         <ColorPicker
-          color={fill.color}
+          color={solidColor}
           opacity={fill.opacity}
           onChange={(color) => onUpdate({ color })}
           onOpacityChange={(opacity) => onUpdate({ opacity })}

--- a/apps/web/src/pages/editor/hooks/canvas-draw-selection.ts
+++ b/apps/web/src/pages/editor/hooks/canvas-draw-selection.ts
@@ -121,7 +121,7 @@ export function renderAiShimmerOverlays(
     let isLightBackground = true;
     if ('fills' in shape && Array.isArray(shape.fills)) {
       const visibleFill = shape.fills.find((f) => f.visible);
-      if (visibleFill) {
+      if (visibleFill?.color) {
         const hex = visibleFill.color.replace('#', '');
         const r = parseInt(hex.substring(0, 2), 16);
         const g = parseInt(hex.substring(2, 4), 16);

--- a/apps/website/content/docs/0.x/advanced/mcp.md
+++ b/apps/website/content/docs/0.x/advanced/mcp.md
@@ -121,6 +121,15 @@ The MCP server exposes 30+ tools organized into categories.
 | `list_icons`            | List available Lucide icons                              |
 | `insert_icon`           | Insert a Lucide icon as SVG                              |
 
+#### Images in PNG exports
+
+`export_png` renders on the server, so every image it needs is fetched before drawing:
+
+- Data URIs (including icons and imported SVG) are decoded locally
+- `http(s)` URLs are downloaded, following up to 3 redirects, with a 10 second timeout and a 20 MB limit per image
+- Requests to loopback, link-local, and private network addresses are rejected, so images hosted on an internal network will not render
+- An image that cannot be loaded degrades gracefully: image layers show a grey placeholder and image fills are skipped, the rest of the export still renders
+
 ### Guides and Variables
 
 | Tool              | Description                    |

--- a/apps/website/content/docs/0.x/advanced/mcp.md
+++ b/apps/website/content/docs/0.x/advanced/mcp.md
@@ -127,7 +127,10 @@ The MCP server exposes 30+ tools organized into categories.
 
 - Data URIs (including icons and imported SVG) are decoded locally
 - `http(s)` URLs are downloaded, following up to 3 redirects, with a 10 second timeout and a 20 MB limit per image
+- The host is resolved once and the connection is pinned to that address, so a hostname cannot resolve to a public address during the check and a private one during the request
 - Requests to loopback, link-local, and private network addresses are rejected, so images hosted on an internal network will not render
+- Images that decode to more than 30 megapixels are rejected, as are formats whose dimensions cannot be read, so a small file cannot expand into a very large bitmap
+- A single export loads at most 200 distinct images and spends at most 30 seconds loading them; anything beyond that is left unloaded
 - An image that cannot be loaded degrades gracefully: image layers show a grey placeholder and image fills are skipped, the rest of the export still renders
 
 ### Guides and Variables

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@prisma/client": "^6.7.0",
         "better-auth": "^1.1.14",
         "hono": "^4.6.14",
+        "image-size": "^2.0.2",
         "jszip": "^3.10.1",
         "lib0": "^0.2.117",
         "linkedom": "^0.18.12",
@@ -1335,6 +1336,8 @@
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "image-size": ["image-size@2.0.2", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -20,6 +20,7 @@
     "./clipboard": "./src/clipboard.ts",
     "./shape-import": "./src/shape-import.ts",
     "./boolean-ops": "./src/boolean-ops.ts",
+    "./image-cache": "./src/image-cache.ts",
     "./image-manager": "./src/image-manager.ts",
     "./auto-layout": "./src/auto-layout.ts",
     "./font-manager": "./src/font-manager.ts",

--- a/packages/engine/src/codegen/compose-generator.ts
+++ b/packages/engine/src/codegen/compose-generator.ts
@@ -83,6 +83,7 @@ function hexToComposeColor(hex: string, opacity: number): string {
 }
 
 function fillToComposeColor(fill: Fill): string {
+  if (!fill.color) return 'Color.Transparent';
   return hexToComposeColor(fill.color, fill.opacity);
 }
 

--- a/packages/engine/src/codegen/css-generator.ts
+++ b/packages/engine/src/codegen/css-generator.ts
@@ -178,6 +178,7 @@ function fillToCssValue(fill: Fill): string {
   if (fill.imageSrc) {
     return `url("${escapeCssDoubleQuotedString(fill.imageSrc)}")`;
   }
+  if (!fill.color) return 'transparent';
   const rgba = hexToRgba(fill.color, fill.opacity);
   return rgbaToCssColor(rgba);
 }
@@ -448,7 +449,7 @@ function textProperties(shape: TextShape, ctx?: ShapeContext): string[] {
       props.push(`background: ${gradientValue};`);
       props.push('-webkit-background-clip: text;');
       props.push('-webkit-text-fill-color: transparent;');
-    } else {
+    } else if (fill.color) {
       const rgba = hexToRgba(fill.color, fill.opacity);
       props.push(`color: ${rgbaToCssColor(rgba)};`);
     }

--- a/packages/engine/src/codegen/swiftui-generator.ts
+++ b/packages/engine/src/codegen/swiftui-generator.ts
@@ -120,6 +120,7 @@ function fillToSwiftUI(fill: Fill, width = 0, height = 0): string {
   if (fill.gradient) {
     return gradientToSwiftUI(fill.gradient, fill.opacity, width, height);
   }
+  if (!fill.color) return 'Color.clear';
   const rgba = hexToRgba(fill.color, fill.opacity);
   return rgbaToSwiftUIColor(rgba.r, rgba.g, rgba.b, rgba.a);
 }
@@ -517,7 +518,7 @@ function textToSwiftUI(shape: TextShape): string {
       modifiers.push(
         `.foregroundStyle(${gradientToSwiftUI(fill.gradient, fill.opacity, shape.width, shape.height)})`,
       );
-    } else {
+    } else if (fill.color) {
       const rgba = hexToRgba(fill.color, fill.opacity);
       modifiers.push(`.foregroundColor(${rgbaToSwiftUIColor(rgba.r, rgba.g, rgba.b, rgba.a)})`);
     }

--- a/packages/engine/src/codegen/tailwind-generator.ts
+++ b/packages/engine/src/codegen/tailwind-generator.ts
@@ -289,6 +289,7 @@ function singleFillToTailwind(fill: Fill, prefix: string): string[] {
   if (fill.imageSrc) {
     return [`${prefix}-[url('${fill.imageSrc}')]`];
   }
+  if (!fill.color) return [];
   return [`${prefix}-[${colorToTailwind(fill.color, fill.opacity)}]`];
 }
 
@@ -299,6 +300,7 @@ function fillToCssValue(fill: Fill): string {
   if (fill.imageSrc) {
     return `url('${fill.imageSrc}')`;
   }
+  if (!fill.color) return 'transparent';
   const rgba = hexToRgba(fill.color, fill.opacity);
   return rgbaToCssColor(rgba);
 }
@@ -653,7 +655,7 @@ function textClasses(shape: TextShape, ctx?: ShapeContext): string[] {
     if (fill.gradient) {
       classes.push(...gradientToTailwind(fill.gradient, fill.opacity));
       classes.push('bg-clip-text', 'text-transparent');
-    } else {
+    } else if (fill.color) {
       classes.push(`text-[${colorToTailwind(fill.color, fill.opacity)}]`);
     }
   }

--- a/packages/engine/src/export.ts
+++ b/packages/engine/src/export.ts
@@ -5,6 +5,7 @@ import { renderShape, getCornerRadii } from './shape-renderer';
 import { shapesToInterchange } from './interchange/converter';
 import { generateSvg } from './interchange/svg/svg-generator';
 import { collectFontFamilies, ensureFontsLoadedAsync } from './font-manager';
+import { collectImageSources, preloadImages } from './image-cache';
 
 function getShapesBounds(shapes: Shape[]): {
   minX: number;
@@ -80,6 +81,8 @@ export async function exportToPng(
     await ensureFontsLoadedAsync(families);
   }
 
+  await preloadImages(collectImageSources(shapes));
+
   const { minX, minY, maxX, maxY } = getShapesBounds(shapes);
 
   const width = maxX - minX;
@@ -148,6 +151,8 @@ export async function exportToJpg(
   if (families.length > 0) {
     await ensureFontsLoadedAsync(families);
   }
+
+  await preloadImages(collectImageSources(shapes));
 
   const { minX, minY, maxX, maxY } = getShapesBounds(shapes);
 

--- a/packages/engine/src/image-cache.ts
+++ b/packages/engine/src/image-cache.ts
@@ -1,0 +1,143 @@
+import type { Fill, Shape } from '@draftila/shared';
+
+export type ImageLoader = (src: string) => Promise<HTMLImageElement>;
+
+interface CacheEntry {
+  image: HTMLImageElement;
+  bytes: number;
+}
+
+const DEFAULT_PRELOAD_CONCURRENCY = 8;
+
+const cache = new Map<string, CacheEntry>();
+const pendingLoads = new Map<string, Promise<HTMLImageElement>>();
+const failedSources = new Set<string>();
+
+let cacheLimitBytes = Number.POSITIVE_INFINITY;
+let cachedBytes = 0;
+
+function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    image.src = src;
+  });
+}
+
+let loadImageSource: ImageLoader = loadImageElement;
+
+export function setImageLoader(loader: ImageLoader) {
+  loadImageSource = loader;
+}
+
+export function setImageCacheLimit(bytes: number) {
+  cacheLimitBytes = bytes;
+  evictOverflow();
+}
+
+function estimateBytes(image: HTMLImageElement): number {
+  return Math.max(image.naturalWidth * image.naturalHeight * 4, 1);
+}
+
+function evictOverflow() {
+  for (const [src, entry] of cache) {
+    if (cachedBytes <= cacheLimitBytes || cache.size <= 1) return;
+    cache.delete(src);
+    cachedBytes -= entry.bytes;
+  }
+}
+
+export function registerImage(src: string, image: HTMLImageElement) {
+  const existing = cache.get(src);
+  if (existing) cachedBytes -= existing.bytes;
+
+  const bytes = estimateBytes(image);
+  cache.set(src, { image, bytes });
+  cachedBytes += bytes;
+  failedSources.delete(src);
+  evictOverflow();
+}
+
+export function getCachedImage(src: string): HTMLImageElement | null {
+  const entry = cache.get(src);
+  if (!entry) return null;
+  cache.delete(src);
+  cache.set(src, entry);
+  return entry.image;
+}
+
+export function preloadImage(src: string): Promise<HTMLImageElement> {
+  const cached = getCachedImage(src);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = pendingLoads.get(src);
+  if (pending) return pending;
+
+  const load = loadImageSource(src).then(
+    (image) => {
+      pendingLoads.delete(src);
+      registerImage(src, image);
+      return image;
+    },
+    (error: unknown) => {
+      pendingLoads.delete(src);
+      failedSources.add(src);
+      throw error;
+    },
+  );
+
+  pendingLoads.set(src, load);
+  return load;
+}
+
+export function resolveImage(src: string): HTMLImageElement | null {
+  const cached = getCachedImage(src);
+  if (cached) return cached;
+  if (!failedSources.has(src)) void preloadImage(src).catch(() => null);
+  return null;
+}
+
+export async function preloadImages(
+  sources: string[],
+  concurrency = DEFAULT_PRELOAD_CONCURRENCY,
+): Promise<void> {
+  const queue = [...new Set(sources)];
+  const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
+    for (let src = queue.shift(); src !== undefined; src = queue.shift()) {
+      await preloadImage(src).catch(() => null);
+    }
+  });
+  await Promise.all(workers);
+}
+
+export function clearImageCache() {
+  cache.clear();
+  pendingLoads.clear();
+  failedSources.clear();
+  cachedBytes = 0;
+}
+
+export function svgToDataUri(svgContent: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
+}
+
+export function collectImageSources(shapes: Shape[]): string[] {
+  const sources = new Set<string>();
+
+  for (const shape of shapes) {
+    if (shape.type === 'image' && shape.src) {
+      sources.add(shape.src);
+    }
+    if (shape.type === 'svg' && shape.svgContent) {
+      sources.add(svgToDataUri(shape.svgContent));
+    }
+    const fills = (shape as Shape & { fills?: Fill[] }).fills ?? [];
+    for (const fill of fills) {
+      if (fill.imageSrc) sources.add(fill.imageSrc);
+    }
+  }
+
+  return [...sources];
+}

--- a/packages/engine/src/image-cache.ts
+++ b/packages/engine/src/image-cache.ts
@@ -8,6 +8,21 @@ interface CacheEntry {
 }
 
 const DEFAULT_PRELOAD_CONCURRENCY = 8;
+const DEFAULT_PRELOAD_LIMIT = 500;
+const DEFAULT_PRELOAD_TIMEOUT_MS = 60_000;
+
+export interface PreloadImagesOptions {
+  concurrency?: number;
+  limit?: number;
+  timeoutMs?: number;
+}
+
+export interface PreloadImagesResult {
+  requested: number;
+  loaded: number;
+  failed: number;
+  skipped: number;
+}
 
 const cache = new Map<string, CacheEntry>();
 const pendingLoads = new Map<string, Promise<HTMLImageElement>>();
@@ -101,15 +116,30 @@ export function resolveImage(src: string): HTMLImageElement | null {
 
 export async function preloadImages(
   sources: string[],
-  concurrency = DEFAULT_PRELOAD_CONCURRENCY,
-): Promise<void> {
-  const queue = [...new Set(sources)];
+  options: PreloadImagesOptions = {},
+): Promise<PreloadImagesResult> {
+  const concurrency = options.concurrency ?? DEFAULT_PRELOAD_CONCURRENCY;
+  const limit = options.limit ?? DEFAULT_PRELOAD_LIMIT;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PRELOAD_TIMEOUT_MS;
+
+  const unique = [...new Set(sources)];
+  const queue = unique.slice(0, limit);
+  const expiresAt = Date.now() + timeoutMs;
+
+  let loaded = 0;
+  let failed = 0;
+
   const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
     for (let src = queue.shift(); src !== undefined; src = queue.shift()) {
-      await preloadImage(src).catch(() => null);
+      if (Date.now() >= expiresAt) return;
+      const image = await preloadImage(src).catch(() => null);
+      if (image) loaded++;
+      else failed++;
     }
   });
   await Promise.all(workers);
+
+  return { requested: unique.length, loaded, failed, skipped: unique.length - loaded - failed };
 }
 
 export function clearImageCache() {

--- a/packages/engine/src/image-manager.ts
+++ b/packages/engine/src/image-manager.ts
@@ -1,31 +1,6 @@
 import type * as Y from 'yjs';
 import { addShape } from './scene-graph';
-
-const imageCache = new Map<string, HTMLImageElement>();
-
-export function getCachedImage(src: string): HTMLImageElement | null {
-  return imageCache.get(src) ?? null;
-}
-
-export function preloadImage(src: string): Promise<HTMLImageElement> {
-  const cached = imageCache.get(src);
-  if (cached) return Promise.resolve(cached);
-
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.crossOrigin = 'anonymous';
-    img.onload = () => {
-      imageCache.set(src, img);
-      resolve(img);
-    };
-    img.onerror = reject;
-    img.src = src;
-  });
-}
-
-export function clearImageCache() {
-  imageCache.clear();
-}
+import { preloadImage, registerImage } from './image-cache';
 
 export async function addImageFromFile(
   ydoc: Y.Doc,
@@ -60,7 +35,7 @@ export async function addImageFromFile(
           parentId: parentId ?? null,
         });
 
-        imageCache.set(dataUrl, img);
+        registerImage(dataUrl, img);
         resolve(id);
       };
       img.onerror = reject;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -156,13 +156,19 @@ export {
 } from './boolean-ops';
 
 export {
+  type ImageLoader,
   getCachedImage,
   preloadImage,
+  preloadImages,
+  registerImage,
   clearImageCache,
-  addImageFromFile,
-  addImageFromUrl,
-  handleFileDrop,
-} from './image-manager';
+  collectImageSources,
+  setImageLoader,
+  setImageCacheLimit,
+  svgToDataUri,
+} from './image-cache';
+
+export { addImageFromFile, addImageFromUrl, handleFileDrop } from './image-manager';
 
 export {
   type LayoutChild,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -157,6 +157,8 @@ export {
 
 export {
   type ImageLoader,
+  type PreloadImagesOptions,
+  type PreloadImagesResult,
   getCachedImage,
   preloadImage,
   preloadImages,

--- a/packages/engine/src/interchange/interchange-format.ts
+++ b/packages/engine/src/interchange/interchange-format.ts
@@ -12,7 +12,7 @@ export type InterchangeNodeType =
   | 'group';
 
 export interface InterchangeFill {
-  color: string;
+  color?: string;
   opacity: number;
   visible: boolean;
 }

--- a/packages/engine/src/interchange/svg/svg-generator.ts
+++ b/packages/engine/src/interchange/svg/svg-generator.ts
@@ -157,7 +157,7 @@ function renderFillsAndStrokes(
     parts.push(`<${geom.tag} ${geom.attrs} fill="url(#${gradientIds[0]})" stroke="none"/>`);
   } else if (visibleFills.length > 0) {
     for (const fill of visibleFills) {
-      const color = svgColor(fill.color, fill.opacity);
+      const color = fill.color ? svgColor(fill.color, fill.opacity) : 'none';
       parts.push(`<${geom.tag} ${geom.attrs} fill="${color}" stroke="none"/>`);
     }
   } else if (visibleStrokes.length === 0) {
@@ -317,7 +317,7 @@ function nodeToSvg(
       else if (node.textTransform === 'lowercase') textContent = textContent.toLowerCase();
 
       const visibleFill = node.fills.find((f) => f.visible);
-      const fillAttr = visibleFill
+      const fillAttr = visibleFill?.color
         ? ` fill="${svgColor(visibleFill.color, visibleFill.opacity)}"`
         : ' fill="#000000"';
 

--- a/packages/engine/src/renderer/canvas2d-renderer.ts
+++ b/packages/engine/src/renderer/canvas2d-renderer.ts
@@ -14,7 +14,6 @@ import * as uiDraw from './ui-draw';
 import * as guidesDraw from './guides-draw';
 
 export class Canvas2DRenderer implements Renderer {
-  private static imageCache = new Map<string, HTMLImageElement>();
   private ctx: CanvasRenderingContext2D;
   private canvas: HTMLCanvasElement;
   private dpr = 1;
@@ -35,7 +34,7 @@ export class Canvas2DRenderer implements Renderer {
     const ctx = canvas.getContext('2d');
     if (!ctx) throw new Error('Failed to get 2d context');
     this.ctx = ctx;
-    this.se = new StyleEngine(ctx, canvas, this.dpr, Canvas2DRenderer.imageCache);
+    this.se = new StyleEngine(ctx, canvas, this.dpr);
   }
 
   resize(width: number, height: number, dpr: number) {

--- a/packages/engine/src/renderer/shape-draw.ts
+++ b/packages/engine/src/renderer/shape-draw.ts
@@ -125,12 +125,22 @@ export function drawPath(
 
   for (const fill of style.fills) {
     if (!fill.visible) continue;
+    if (fill.imageSrc) {
+      ctx.save();
+      ctx.clip(path);
+      ctx.translate(pathMinX, pathMinY);
+      const painted = se.drawImageFill(fill, pathWidth, pathHeight);
+      ctx.restore();
+      if (painted) continue;
+    }
     if (fill.gradient) {
       ctx.save();
       ctx.translate(pathMinX, pathMinY);
-      ctx.fillStyle = se.getFillStyle(fill, pathWidth, pathHeight);
+      const gradientStyle = se.getFillStyle(fill, pathWidth, pathHeight);
+      if (gradientStyle) ctx.fillStyle = gradientStyle;
       ctx.translate(-pathMinX, -pathMinY);
     } else {
+      if (!fill.color) continue;
       ctx.fillStyle = colorWithOpacity(fill.color, fill.opacity);
     }
     if (dropShadows.length > 0) {
@@ -195,7 +205,16 @@ export function drawSvgPath(
 
   for (const fill of style.fills) {
     if (!fill.visible) continue;
-    ctx.fillStyle = se.getFillStyle(fill, transform.width, transform.height);
+    if (fill.imageSrc) {
+      ctx.save();
+      ctx.clip(path, fillRule);
+      const painted = se.drawImageFill(fill, transform.width, transform.height);
+      ctx.restore();
+      if (painted) continue;
+    }
+    const fillStyle = se.getFillStyle(fill, transform.width, transform.height);
+    if (!fillStyle) continue;
+    ctx.fillStyle = fillStyle;
     if (dropShadows.length > 0) {
       for (const shadow of dropShadows) {
         se.applyDropShadow(shadow);

--- a/packages/engine/src/renderer/style-engine.ts
+++ b/packages/engine/src/renderer/style-engine.ts
@@ -1,23 +1,17 @@
 import type { Fill, Gradient, Shadow, Stroke } from '@draftila/shared';
 import type { RenderStyle, RenderTransform } from './types';
 import { colorWithOpacity, resolveDashArray, shadowColorToRgba } from './style-utils';
+import { resolveImage } from '../image-cache';
 
 export class StyleEngine {
   private ctx: CanvasRenderingContext2D;
   private canvas: HTMLCanvasElement;
   private dpr: number;
-  private imageCache: Map<string, HTMLImageElement>;
 
-  constructor(
-    ctx: CanvasRenderingContext2D,
-    canvas: HTMLCanvasElement,
-    dpr: number,
-    imageCache: Map<string, HTMLImageElement>,
-  ) {
+  constructor(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, dpr: number) {
     this.ctx = ctx;
     this.canvas = canvas;
     this.dpr = dpr;
-    this.imageCache = imageCache;
   }
 
   updateDpr(dpr: number) {
@@ -40,15 +34,8 @@ export class StyleEngine {
   getLoadedImage(src: string): HTMLImageElement | null {
     if (!src) return null;
 
-    let image = this.imageCache.get(src);
-    if (!image) {
-      image = new Image();
-      image.crossOrigin = 'anonymous';
-      image.src = src;
-      this.imageCache.set(src, image);
-    }
-
-    if (!image.complete || image.naturalWidth <= 0 || image.naturalHeight <= 0) {
+    const image = resolveImage(src);
+    if (!image || image.naturalWidth <= 0 || image.naturalHeight <= 0) {
       return null;
     }
 
@@ -86,9 +73,45 @@ export class StyleEngine {
     return canvasGradient;
   }
 
-  getFillStyle(fill: Fill, width: number, height: number): string | CanvasGradient {
+  drawImageFill(fill: Fill, width: number, height: number): boolean {
+    if (!fill.imageSrc) return false;
+
+    const image = this.getLoadedImage(fill.imageSrc);
+    if (!image) return false;
+
+    const { ctx } = this;
+    ctx.globalAlpha *= fill.opacity ?? 1;
+    const fit = fill.imageFit ?? 'fill';
+
+    if (fit === 'tile') {
+      const pattern = ctx.createPattern(image, 'repeat');
+      if (pattern) {
+        ctx.fillStyle = pattern;
+        ctx.fillRect(0, 0, width, height);
+      }
+      return true;
+    }
+
+    if (fit === 'fill') {
+      ctx.drawImage(image, 0, 0, width, height);
+      return true;
+    }
+
+    const scaleX = width / image.naturalWidth;
+    const scaleY = height / image.naturalHeight;
+    const scale = fit === 'fit' ? Math.min(scaleX, scaleY) : Math.max(scaleX, scaleY);
+    const drawWidth = image.naturalWidth * scale;
+    const drawHeight = image.naturalHeight * scale;
+    ctx.drawImage(image, (width - drawWidth) / 2, (height - drawHeight) / 2, drawWidth, drawHeight);
+    return true;
+  }
+
+  getFillStyle(fill: Fill, width: number, height: number): string | CanvasGradient | null {
     if (fill.gradient) {
       return this.createGradient(fill.gradient, width, height);
+    }
+    if (!fill.color) {
+      return null;
     }
     return colorWithOpacity(fill.color, fill.opacity);
   }
@@ -199,9 +222,10 @@ export class StyleEngine {
 
     if (dropShadows.length > 0) {
       const firstVisibleFill = style.fills.find((f) => f.visible);
-      ctx.fillStyle = firstVisibleFill
+      const shadowFillStyle = firstVisibleFill
         ? this.getFillStyle(firstVisibleFill, width, height)
-        : 'rgba(0,0,0,0)';
+        : null;
+      ctx.fillStyle = shadowFillStyle ?? 'rgba(0,0,0,0)';
       for (const shadow of dropShadows) {
         this.applyDropShadow(shadow);
         ctx.fill();
@@ -211,47 +235,28 @@ export class StyleEngine {
 
     for (const fill of style.fills) {
       if (!fill.visible) continue;
+      const fillAlpha = fill.opacity ?? 1;
       if (fill.imageSrc) {
-        const img = this.getLoadedImage(fill.imageSrc);
-        if (img) {
-          ctx.save();
-          ctx.clip();
-          ctx.globalAlpha *= fill.opacity;
-          const fit = fill.imageFit ?? 'fill';
-          if (fit === 'fill') {
-            ctx.drawImage(img, 0, 0, width, height);
-          } else if (fit === 'fit') {
-            const scale = Math.min(width / img.naturalWidth, height / img.naturalHeight);
-            const dw = img.naturalWidth * scale;
-            const dh = img.naturalHeight * scale;
-            ctx.drawImage(img, (width - dw) / 2, (height - dh) / 2, dw, dh);
-          } else if (fit === 'crop') {
-            const scale = Math.max(width / img.naturalWidth, height / img.naturalHeight);
-            const dw = img.naturalWidth * scale;
-            const dh = img.naturalHeight * scale;
-            ctx.drawImage(img, (width - dw) / 2, (height - dh) / 2, dw, dh);
-          } else if (fit === 'tile') {
-            const pattern = ctx.createPattern(img, 'repeat');
-            if (pattern) {
-              const previousFillStyle = ctx.fillStyle;
-              ctx.fillStyle = pattern;
-              ctx.fillRect(0, 0, width, height);
-              ctx.fillStyle = previousFillStyle;
-            }
-          }
-          ctx.globalAlpha = style.opacity;
-          ctx.restore();
-        } else {
-          ctx.fillStyle = this.getFillStyle(fill, width, height);
-          ctx.globalAlpha *= fill.opacity;
+        ctx.save();
+        ctx.clip();
+        const painted = this.drawImageFill(fill, width, height);
+        ctx.restore();
+        if (painted) continue;
+
+        const placeholderStyle = this.getFillStyle(fill, width, height);
+        if (placeholderStyle) {
+          ctx.fillStyle = placeholderStyle;
+          ctx.globalAlpha *= fillAlpha;
           ctx.fill();
           ctx.globalAlpha = style.opacity;
         }
         continue;
       }
-      ctx.fillStyle = this.getFillStyle(fill, width, height);
+      const fillStyle = this.getFillStyle(fill, width, height);
+      if (!fillStyle) continue;
+      ctx.fillStyle = fillStyle;
       if (!fill.gradient) {
-        ctx.globalAlpha *= fill.opacity;
+        ctx.globalAlpha *= fillAlpha;
       }
       ctx.fill();
       if (!fill.gradient) {

--- a/packages/engine/src/renderer/style-utils.ts
+++ b/packages/engine/src/renderer/style-utils.ts
@@ -83,7 +83,7 @@ export function dashPatternToArray(pattern: StrokeDashPattern, strokeWidth: numb
   }
 }
 
-export function colorWithOpacity(hex: string, opacity: number): string {
+export function colorWithOpacity(hex: string, opacity = 1): string {
   if (opacity >= 1) return hex;
   if (opacity <= 0) return 'transparent';
   const r = parseInt(hex.slice(1, 3), 16);

--- a/packages/engine/src/renderer/text-draw.ts
+++ b/packages/engine/src/renderer/text-draw.ts
@@ -45,7 +45,7 @@ function drawPlainText(
 
   const visibleFill = options.fills.find((f) => f.visible);
   const fillStyle: string | CanvasGradient | null = visibleFill
-    ? se.getFillStyle(visibleFill, transform.width, transform.height)
+    ? (se.getFillStyle(visibleFill, transform.width, transform.height) ?? '#000000')
     : null;
 
   if (fillStyle) {
@@ -112,7 +112,7 @@ function drawPlainText(
           : lineTopY + options.fontSize * 0.95;
       ctx.beginPath();
       ctx.strokeStyle =
-        typeof fillStyle === 'string' ? fillStyle : visibleFill ? visibleFill.color : '#000000';
+        typeof fillStyle === 'string' ? fillStyle : (visibleFill?.color ?? '#000000');
       ctx.lineWidth = Math.max(1, options.fontSize / 16);
       ctx.moveTo(lineStartX, decoY);
       ctx.lineTo(lineStartX + metrics.width, decoY);
@@ -136,7 +136,7 @@ function drawSegmentedText(
   const baseLetterSpacing = options.letterSpacing;
 
   const visibleFill = options.fills.find((f) => f.visible);
-  const baseColor = visibleFill
+  const baseColor = visibleFill?.color
     ? colorWithOpacity(visibleFill.color, visibleFill.opacity)
     : '#000000';
 

--- a/packages/engine/src/shape-renderer.ts
+++ b/packages/engine/src/shape-renderer.ts
@@ -2,6 +2,7 @@ import type { ArrowheadType, Blur, Fill, Shadow, Shape, Stroke } from '@draftila
 import type { Renderer, RenderStyle, RenderTransform } from './renderer/types';
 import { simpleStyle } from './renderer/types';
 import getStroke from 'perfect-freehand';
+import { svgToDataUri } from './image-cache';
 import {
   computeArrowheadGeometry,
   generatePolygonPoints,
@@ -16,10 +17,6 @@ export {
   generateStarPoints,
   getCornerRadii,
 } from './shape-geometry';
-
-function svgToDataUri(svgContent: string): string {
-  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
-}
 
 function preserveAspectRatioToFit(value: string | undefined): 'fill' | 'fit' | 'crop' {
   const normalized = (value ?? 'xMidYMid meet').trim().toLowerCase();

--- a/packages/engine/tests/image-cache.test.ts
+++ b/packages/engine/tests/image-cache.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import type { Shape } from '@draftila/shared';
+import {
+  clearImageCache,
+  collectImageSources,
+  getCachedImage,
+  preloadImage,
+  preloadImages,
+  registerImage,
+  resolveImage,
+  setImageCacheLimit,
+  setImageLoader,
+  svgToDataUri,
+} from '../src/image-cache';
+
+function fakeImage(size = 1): HTMLImageElement {
+  return { naturalWidth: size, naturalHeight: size } as unknown as HTMLImageElement;
+}
+
+function shape(props: Record<string, unknown>): Shape {
+  return {
+    id: 'shape',
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    rotation: 0,
+    opacity: 1,
+    visible: true,
+    locked: false,
+    ...props,
+  } as unknown as Shape;
+}
+
+describe('image-cache', () => {
+  beforeEach(() => {
+    clearImageCache();
+    setImageCacheLimit(Number.POSITIVE_INFINITY);
+    setImageLoader((src) => Promise.resolve(fakeImage(src.length)));
+  });
+
+  test('caches loaded images and reuses them', async () => {
+    let loads = 0;
+    setImageLoader(() => {
+      loads++;
+      return Promise.resolve(fakeImage());
+    });
+
+    await preloadImage('a.png');
+    await preloadImage('a.png');
+
+    expect(loads).toBe(1);
+    expect(getCachedImage('a.png')).not.toBeNull();
+  });
+
+  test('deduplicates concurrent loads of the same source', async () => {
+    let loads = 0;
+    setImageLoader(() => {
+      loads++;
+      return Promise.resolve(fakeImage());
+    });
+
+    await Promise.all([preloadImage('a.png'), preloadImage('a.png')]);
+
+    expect(loads).toBe(1);
+  });
+
+  test('does not cache images that fail to load', async () => {
+    setImageLoader(() => Promise.reject(new Error('boom')));
+
+    await expect(preloadImage('broken.png')).rejects.toThrow('boom');
+    expect(getCachedImage('broken.png')).toBeNull();
+  });
+
+  test('resolveImage requests a missing image once and stops retrying after failure', async () => {
+    let loads = 0;
+    setImageLoader(() => {
+      loads++;
+      return Promise.reject(new Error('boom'));
+    });
+
+    expect(resolveImage('broken.png')).toBeNull();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolveImage('broken.png')).toBeNull();
+    expect(resolveImage('broken.png')).toBeNull();
+
+    expect(loads).toBe(1);
+  });
+
+  test('resolveImage returns the image once it is loaded', async () => {
+    await preloadImage('a.png');
+    expect(resolveImage('a.png')).not.toBeNull();
+  });
+
+  test('registerImage makes an image available without loading it', () => {
+    setImageLoader(() => Promise.reject(new Error('should not load')));
+    registerImage('local.png', fakeImage());
+
+    expect(resolveImage('local.png')).not.toBeNull();
+  });
+
+  test('evicts least recently used images once the byte limit is exceeded', async () => {
+    setImageCacheLimit(8);
+    setImageLoader(() => Promise.resolve(fakeImage()));
+
+    await preloadImage('a.png');
+    await preloadImage('b.png');
+    getCachedImage('a.png');
+    await preloadImage('c.png');
+
+    expect(getCachedImage('b.png')).toBeNull();
+    expect(getCachedImage('a.png')).not.toBeNull();
+    expect(getCachedImage('c.png')).not.toBeNull();
+  });
+
+  test('keeps a single image cached even when it exceeds the limit', async () => {
+    setImageCacheLimit(1);
+    setImageLoader(() => Promise.resolve(fakeImage(100)));
+
+    await preloadImage('big.png');
+
+    expect(getCachedImage('big.png')).not.toBeNull();
+  });
+
+  test('preloadImages loads every source and swallows failures', async () => {
+    const loaded: string[] = [];
+    setImageLoader((src) => {
+      loaded.push(src);
+      return src === 'bad.png' ? Promise.reject(new Error('boom')) : Promise.resolve(fakeImage());
+    });
+
+    await preloadImages(['a.png', 'b.png', 'bad.png', 'a.png'], 2);
+
+    expect(loaded.toSorted()).toEqual(['a.png', 'b.png', 'bad.png']);
+    expect(getCachedImage('b.png')).not.toBeNull();
+    expect(getCachedImage('bad.png')).toBeNull();
+  });
+
+  test('collects image sources from image shapes, svg shapes and image fills', () => {
+    const svgContent = '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>';
+    const sources = collectImageSources([
+      shape({ id: 'a', type: 'image', src: 'https://example.com/a.png' }),
+      shape({ id: 'b', type: 'svg', svgContent }),
+      shape({ id: 'c', fills: [{ imageSrc: 'https://example.com/b.png', visible: true }] }),
+      shape({ id: 'd', fills: [{ color: '#ffffff', opacity: 1, visible: true }] }),
+      shape({ id: 'e', type: 'image', src: 'https://example.com/a.png' }),
+    ]);
+
+    expect(sources).toEqual([
+      'https://example.com/a.png',
+      svgToDataUri(svgContent),
+      'https://example.com/b.png',
+    ]);
+  });
+
+  test('ignores shapes without image sources', () => {
+    expect(
+      collectImageSources([shape({ type: 'image', src: '' }), shape({ type: 'svg' })]),
+    ).toEqual([]);
+  });
+});

--- a/packages/engine/tests/image-cache.test.ts
+++ b/packages/engine/tests/image-cache.test.ts
@@ -131,11 +131,41 @@ describe('image-cache', () => {
       return src === 'bad.png' ? Promise.reject(new Error('boom')) : Promise.resolve(fakeImage());
     });
 
-    await preloadImages(['a.png', 'b.png', 'bad.png', 'a.png'], 2);
+    const result = await preloadImages(['a.png', 'b.png', 'bad.png', 'a.png'], { concurrency: 2 });
 
     expect(loaded.toSorted()).toEqual(['a.png', 'b.png', 'bad.png']);
     expect(getCachedImage('b.png')).not.toBeNull();
     expect(getCachedImage('bad.png')).toBeNull();
+    expect(result).toEqual({ requested: 3, loaded: 2, failed: 1, skipped: 0 });
+  });
+
+  test('preloadImages stops at the source limit and reports the remainder as skipped', async () => {
+    const loaded: string[] = [];
+    setImageLoader((src) => {
+      loaded.push(src);
+      return Promise.resolve(fakeImage());
+    });
+
+    const result = await preloadImages(['a.png', 'b.png', 'c.png'], { concurrency: 1, limit: 2 });
+
+    expect(loaded).toEqual(['a.png', 'b.png']);
+    expect(result).toEqual({ requested: 3, loaded: 2, failed: 0, skipped: 1 });
+  });
+
+  test('preloadImages abandons remaining sources once the deadline passes', async () => {
+    const loaded: string[] = [];
+    setImageLoader((src) => {
+      loaded.push(src);
+      return new Promise((resolve) => setTimeout(() => resolve(fakeImage()), 20));
+    });
+
+    const result = await preloadImages(['a.png', 'b.png', 'c.png'], {
+      concurrency: 1,
+      timeoutMs: 10,
+    });
+
+    expect(loaded).toEqual(['a.png']);
+    expect(result).toEqual({ requested: 3, loaded: 1, failed: 0, skipped: 2 });
   });
 
   test('collects image sources from image shapes, svg shapes and image fills', () => {

--- a/packages/engine/tests/yjs-utils.test.ts
+++ b/packages/engine/tests/yjs-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'bun:test';
+import * as Y from 'yjs';
+import { valueToYjs, ymapToObject } from '../src/scene-graph/yjs-utils';
+
+function normalizedItems(key: string, value: unknown): Record<string, unknown>[] {
+  const ydoc = new Y.Doc();
+  const holder = ydoc.getMap('holder');
+  holder.set(key, valueToYjs(key, value));
+  const array = holder.get(key) as Y.Array<Y.Map<unknown>>;
+  return array.toArray().map((item) => ymapToObject(item));
+}
+
+describe('valueToYjs', () => {
+  test('applies schema defaults to solid fills', () => {
+    expect(normalizedItems('fills', [{ color: '#00aa00' }])).toEqual([
+      { color: '#00aa00', opacity: 1, visible: true },
+    ]);
+  });
+
+  test('applies schema defaults to image fills that have no color', () => {
+    expect(
+      normalizedItems('fills', [{ imageSrc: 'https://example.com/a.png', imageFit: 'crop' }]),
+    ).toEqual([
+      { opacity: 1, visible: true, imageSrc: 'https://example.com/a.png', imageFit: 'crop' },
+    ]);
+  });
+
+  test('applies schema defaults to gradient fills that have no color', () => {
+    const gradient = {
+      type: 'linear' as const,
+      angle: 90,
+      stops: [
+        { color: '#000000', position: 0 },
+        { color: '#ffffff', position: 1 },
+      ],
+    };
+
+    expect(normalizedItems('fills', [{ gradient }])).toEqual([
+      { opacity: 1, visible: true, gradient },
+    ]);
+  });
+
+  test('applies schema defaults to strokes', () => {
+    expect(normalizedItems('strokes', [{ color: '#000000', width: 2 }])[0]).toMatchObject({
+      color: '#000000',
+      width: 2,
+      opacity: 1,
+      visible: true,
+    });
+  });
+
+  test('keeps fills that define no paint source untouched', () => {
+    expect(normalizedItems('fills', [{ imageFit: 'fill' }])).toEqual([{ imageFit: 'fill' }]);
+  });
+});

--- a/packages/shared/src/schemas/editor.ts
+++ b/packages/shared/src/schemas/editor.ts
@@ -87,14 +87,18 @@ export const gradientSchema = z.discriminatedUnion('type', [
   radialGradientSchema,
 ]);
 
-export const fillSchema = z.object({
-  color: colorSchema,
-  opacity: z.number().min(0).max(1).default(1),
-  visible: z.boolean().default(true),
-  gradient: gradientSchema.optional(),
-  imageSrc: z.string().optional(),
-  imageFit: z.enum(['fill', 'fit', 'crop', 'tile']).optional(),
-});
+export const fillSchema = z
+  .object({
+    color: colorSchema.optional(),
+    opacity: z.number().min(0).max(1).default(1),
+    visible: z.boolean().default(true),
+    gradient: gradientSchema.optional(),
+    imageSrc: z.string().optional(),
+    imageFit: z.enum(['fill', 'fit', 'crop', 'tile']).optional(),
+  })
+  .refine((fill) => fill.color !== undefined || fill.gradient !== undefined || !!fill.imageSrc, {
+    message: 'A fill must define a color, a gradient, or an image source',
+  });
 
 export const strokeCapSchema = z.enum(['butt', 'round', 'square']);
 export const strokeJoinSchema = z.enum(['miter', 'round', 'bevel']);

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "skills": {
+    "code-review": {
+      "source": "saeedvaziry/skills",
+      "ref": "main",
+      "sourceType": "github",
+      "skillPath": "skills/code-review/SKILL.md",
+      "computedHash": "463959fea7d8ba03738b9f21840f713496d853b2001d247df8115b23364515b7"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`export_png` never rendered images. Reproduced against `main`:

| Case | Result on `main` |
| --- | --- |
| `image` shape with a remote `src` | Exports, but draws the grey `#E0E0E0` placeholder |
| rect/frame with `fills: [{imageSrc, visible: true}]` | **Export throws** `TypeError: undefined is not an object (evaluating 'hex.slice')` |
| rect with `fills: [{imageSrc}]` (no `visible`) | Silently renders nothing |
| `svg` shape / any inserted icon | Grey placeholder |

Four separate causes:

1. **Single-pass render never waited for images.** `StyleEngine.getLoadedImage` did browser-style lazy loading — create an `Image`, set `src`, return `null` until `complete`. A browser rAF loop retries until it arrives; the server renders once, so images were always missing.
2. **Percent-encoded data URIs never decode.** `@napi-rs/canvas` assumes base64 for `data:` and fails with `Decode data url failed Base64Error`. Every icon and `svg` shape is encoded that way, so those were permanently broken rather than racing.
3. **Colourless fills crashed the renderer.** Image fills carry no `color`, and `colorWithOpacity` sliced `undefined`.
4. **`fillSchema.color` was required.** `valueToYjs` normalises fills through the schema to apply the `visible: true` / `opacity: 1` defaults; image fills failed validation and were stored raw, so `visible` was `undefined` and the renderer dropped them. Confirmed by inspecting stored shapes: `{color:'#00aa00'}` → `{color, opacity:1, visible:true}`, `{imageSrc, imageFit}` → stored bare.

Separately, image fills were only ever implemented in `drawRect`/`drawEllipse`. Since #61 every rectangle, ellipse, polygon and star carries `svgPathData` and renders through `drawSvgPath`, which had no image-fill support at all — so image fills were dead on the canvas too, not just in export.

## Changes

**Engine**

- New `image-cache.ts`: injectable `ImageLoader`, in-flight dedup, failed-source tracking so a broken URL isn't re-requested every frame, and LRU eviction under a byte budget. Replaces the two separate unbounded caches (`Canvas2DRenderer`'s static map and `image-manager`'s, the latter never read by the renderer).
- `collectImageSources()` / `preloadImages()` so single-pass renderers load everything before drawing; the browser `exportToPng`/`exportToJpg` preload too, so a fresh-doc export can't race image loads.
- Extracted `StyleEngine.drawImageFill`, now used by `applyFillStroke`, `drawSvgPath` and `drawPath` — each clipped to its own path. Also dedupes the fit/scale maths.
- `getFillStyle` returns `null` for a fill with neither colour nor gradient; call sites skip painting. Text with an image fill falls back to black instead of vanishing.

**Shared**

- `fillSchema.color` is optional, with a `.refine()` requiring a colour, gradient or image source. Optional colour handled at the call sites TS flagged: `transparent` / `none` / no class in CSS, Tailwind and SVG export, `Color.clear` / `Color.Transparent` in SwiftUI and Compose, optional `InterchangeFill.color`, and a default in the fill panel and selection-luminance check.

**API**

- New `image-loader.ts`: decodes data URIs locally (percent-encoded included) and fetches `http(s)` with a protocol allowlist, DNS-resolved private/loopback/link-local blocking re-checked across redirects, a 10s timeout and a streaming 20 MB cap. Server-side fetching of URLs from user documents is new attack surface, hence the SSRF guard.
- Wired into `server-rpc` via `setImageLoader`, with images preloaded before rendering.

## Verification

Tested against a live MCP server. Image shapes (including via a 302 redirect), icons, and image fills on rounded rects and ellipses all render; blocked private-IP images degrade to the grey placeholder and unreachable image fills are skipped, with no export failure. The documented minimal form — `fills: [{imageSrc: "https://…", imageFit: "crop"}]`, no `visible`, no `color` — now stores with defaults applied and renders.

New tests: `image-cache.test.ts` (cache, dedup, failure handling, eviction, source collection), `yjs-utils.test.ts` (fill/stroke normalisation defaults, the regression behind cause 4), and `mcp-image-loader.test.ts` (data URIs, redirects, size caps, host restrictions — 100% line coverage on the new API file).

`bun run checks` passes. Docs updated in `advanced/mcp.md` with the fetching rules and degradation behaviour.