### PR TITLE
[Feat] Remember zoom and pan position per page

### DIFF
--- a/apps/web/bunfig.toml
+++ b/apps/web/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup.ts"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "typecheck": "tsc -b",
     "lint": "eslint .",
+    "test": "bun test",
     "lint:fix": "eslint . --fix",
     "clean": "rm -rf dist .turbo"
   },

--- a/apps/web/src/api/drafts.ts
+++ b/apps/web/src/api/drafts.ts
@@ -10,6 +10,7 @@ import type {
 import { draftExportSchema } from '@draftila/shared';
 import { api, ApiError } from '@/lib/api-client';
 import { queryClient } from '@/lib/query-client';
+import { removeDraftCameras } from '@/lib/camera-storage';
 
 const DRAFTS_KEY = ['drafts'] as const;
 
@@ -103,7 +104,8 @@ export function useDeleteDraft(projectId: string) {
   return useMutation({
     mutationFn: (draftId: string) =>
       api.delete<{ ok: true }>(`/api/projects/${projectId}/drafts/${draftId}`),
-    onSuccess: () => {
+    onSuccess: (_data, draftId) => {
+      removeDraftCameras(draftId);
       queryClient.invalidateQueries({ queryKey: [...DRAFTS_KEY, projectId] });
       queryClient.invalidateQueries({ queryKey: [...DRAFTS_KEY, 'all'] });
     },

--- a/apps/web/src/lib/camera-storage.ts
+++ b/apps/web/src/lib/camera-storage.ts
@@ -1,0 +1,390 @@
+import type { Camera } from '@draftila/shared';
+import { clampZoom } from '@draftila/engine/camera';
+
+export const CAMERA_STORAGE_PREFIX = 'draftila:camera:';
+export const CAMERA_STORAGE_VERSION = 1;
+export const MAX_TRACKED_DRAFTS = 30;
+export const MAX_TRACKED_PAGES_PER_DRAFT = 40;
+
+/**
+ * Camera x/y are screen-space offsets (roughly `-worldCoord * zoom + screenOffset`).
+ * With MAX_ZOOM = 256 this admits world coordinates up to ~3.9e7 while still
+ * rejecting garbage that would render a blank void.
+ */
+const MAX_OFFSET = 1e10;
+
+export interface StoredPageCamera {
+  x: number;
+  y: number;
+  zoom: number;
+  /** Canvas viewport size at save time, used to re-centre when the window changed. */
+  vw?: number;
+  vh?: number;
+  t: number;
+}
+
+export interface DraftCameraRecord {
+  v: number;
+  t: number;
+  pages: Record<string, StoredPageCamera>;
+}
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+let warned = false;
+
+function warnOnce(): void {
+  if (warned) return;
+  warned = true;
+  console.warn('[camera-storage] unable to persist camera state');
+}
+
+function getStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function keyFor(draftId: string): string {
+  return `${CAMERA_STORAGE_PREFIX}${draftId}`;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function sanitizeViewport(viewport: ViewportSize | null | undefined): ViewportSize | null {
+  if (!viewport) return null;
+  const { width, height } = viewport;
+  if (!isFiniteNumber(width) || !isFiniteNumber(height)) return null;
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+export function sanitizeStoredCamera(value: unknown): StoredPageCamera | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const { x, y, zoom, vw, vh, t } = value as Record<string, unknown>;
+  if (!isFiniteNumber(x) || !isFiniteNumber(y) || !isFiniteNumber(zoom)) return null;
+  if (Math.abs(x) > MAX_OFFSET || Math.abs(y) > MAX_OFFSET) return null;
+
+  const stored: StoredPageCamera = {
+    x,
+    y,
+    zoom: clampZoom(zoom),
+    t: isFiniteNumber(t) ? t : 0,
+  };
+
+  const viewport = sanitizeViewport(
+    isFiniteNumber(vw) && isFiniteNumber(vh) ? { width: vw, height: vh } : null,
+  );
+  if (viewport) {
+    stored.vw = viewport.width;
+    stored.vh = viewport.height;
+  }
+
+  return stored;
+}
+
+export function parseDraftRecord(raw: string | null): DraftCameraRecord | null {
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const { v, t, pages } = parsed as Record<string, unknown>;
+  if (v !== CAMERA_STORAGE_VERSION) return null;
+  if (typeof pages !== 'object' || pages === null || Array.isArray(pages)) return null;
+
+  const record: DraftCameraRecord = {
+    v: CAMERA_STORAGE_VERSION,
+    t: isFiniteNumber(t) ? t : 0,
+    pages: {},
+  };
+
+  for (const [pageId, entry] of Object.entries(pages as Record<string, unknown>)) {
+    const camera = sanitizeStoredCamera(entry);
+    if (camera) record.pages[pageId] = camera;
+  }
+
+  return record;
+}
+
+/**
+ * Drop the oldest page entries until at most `max` remain. `keepPageId` is never
+ * evicted: `t` ties are reachable in production (a single flush writes every
+ * pending entry in one task), which would otherwise make the victim
+ * sort-order-dependent and could drop the entry just written.
+ */
+export function prunePages(
+  record: DraftCameraRecord,
+  max: number,
+  keepPageId: string,
+): DraftCameraRecord {
+  const ids = Object.keys(record.pages);
+  if (ids.length <= max) return record;
+
+  const pages = { ...record.pages };
+  const candidates = ids
+    .filter((id) => id !== keepPageId)
+    .sort((a, b) => (pages[a]?.t ?? 0) - (pages[b]?.t ?? 0));
+
+  let count = ids.length;
+  for (const id of candidates) {
+    if (count <= max) break;
+    delete pages[id];
+    count--;
+  }
+
+  return { ...record, pages };
+}
+
+function listCameraKeys(storage: Storage): string[] {
+  const keys: string[] = [];
+  try {
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i);
+      if (key !== null && key.startsWith(CAMERA_STORAGE_PREFIX)) keys.push(key);
+    }
+  } catch {
+    return keys;
+  }
+  return keys;
+}
+
+/** Sort key for LRU eviction. Unparseable records go first so they cannot become immortal. */
+function recordTime(storage: Storage, key: string): number {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return -Infinity;
+  }
+  const record = parseDraftRecord(raw);
+  if (!record || !Number.isFinite(record.t)) return -Infinity;
+  return record.t;
+}
+
+function isQuotaError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const { name, code } = error as { name?: unknown; code?: unknown };
+  return (
+    name === 'QuotaExceededError' ||
+    name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    code === 22 ||
+    code === 1014
+  );
+}
+
+/**
+ * Write, and on quota exhaustion free other camera keys oldest-first, retrying
+ * after each removal. Never throws.
+ */
+function writeRecord(storage: Storage, key: string, record: DraftCameraRecord): boolean {
+  const json = JSON.stringify(record);
+
+  try {
+    storage.setItem(key, json);
+    return true;
+  } catch (error) {
+    if (!isQuotaError(error)) {
+      warnOnce();
+      return false;
+    }
+  }
+
+  const candidates = listCameraKeys(storage)
+    .filter((candidate) => candidate !== key)
+    .map((candidate) => ({ key: candidate, t: recordTime(storage, candidate) }))
+    .sort((a, b) => a.t - b.t);
+
+  for (const candidate of candidates) {
+    try {
+      storage.removeItem(candidate.key);
+    } catch {
+      // Nothing else to try for this candidate.
+    }
+    try {
+      storage.setItem(key, json);
+      return true;
+    } catch (error) {
+      if (!isQuotaError(error)) {
+        warnOnce();
+        return false;
+      }
+    }
+  }
+
+  warnOnce();
+  return false;
+}
+
+/**
+ * Enforce the cross-draft cap. Runs only when a draft key was created, and only
+ * after the write, so the count it sees already includes the new key.
+ */
+function evictDraftsBeyondCap(storage: Storage, justWrittenKey: string): void {
+  const keys = listCameraKeys(storage);
+  if (keys.length <= MAX_TRACKED_DRAFTS) return;
+
+  const candidates = keys
+    .filter((key) => key !== justWrittenKey)
+    .map((key) => ({ key, t: recordTime(storage, key) }))
+    .sort((a, b) => a.t - b.t);
+
+  let count = keys.length;
+  for (const candidate of candidates) {
+    if (count <= MAX_TRACKED_DRAFTS) break;
+    try {
+      storage.removeItem(candidate.key);
+    } catch {
+      // Skip keys we cannot remove; the loop still terminates.
+    }
+    count--;
+  }
+}
+
+export function loadPageCamera(draftId: string, pageId: string): StoredPageCamera | null {
+  const storage = getStorage();
+  if (!storage || !draftId || !pageId) return null;
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(keyFor(draftId));
+  } catch {
+    return null;
+  }
+
+  return parseDraftRecord(raw)?.pages[pageId] ?? null;
+}
+
+export function savePageCamera(
+  draftId: string,
+  pageId: string,
+  camera: Camera,
+  viewport: ViewportSize | null,
+): void {
+  const storage = getStorage();
+  if (!storage || !draftId || !pageId) return;
+  if (!isFiniteNumber(camera.x) || !isFiniteNumber(camera.y) || !isFiniteNumber(camera.zoom)) {
+    return;
+  }
+
+  const key = keyFor(draftId);
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return;
+  }
+
+  // Detected from the raw value, not the parsed one: a corrupt existing key must
+  // not be mistaken for a new draft and trigger the cross-draft sweep every save.
+  const isNewKey = raw === null;
+  const existing = parseDraftRecord(raw);
+  const now = Date.now();
+
+  const entry: StoredPageCamera = {
+    x: camera.x,
+    y: camera.y,
+    zoom: clampZoom(camera.zoom),
+    t: now,
+  };
+  const size = sanitizeViewport(viewport);
+  if (size) {
+    entry.vw = size.width;
+    entry.vh = size.height;
+  }
+
+  const record: DraftCameraRecord = {
+    v: CAMERA_STORAGE_VERSION,
+    t: now,
+    pages: { ...(existing?.pages ?? {}), [pageId]: entry },
+  };
+
+  if (!writeRecord(storage, key, prunePages(record, MAX_TRACKED_PAGES_PER_DRAFT, pageId))) {
+    return;
+  }
+
+  if (isNewKey) evictDraftsBeyondCap(storage, key);
+}
+
+export function removePageCamera(draftId: string, pageId: string): void {
+  const storage = getStorage();
+  if (!storage || !draftId || !pageId) return;
+
+  const key = keyFor(draftId);
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return;
+  }
+
+  const record = parseDraftRecord(raw);
+  if (!record || !(pageId in record.pages)) return;
+
+  delete record.pages[pageId];
+
+  try {
+    if (Object.keys(record.pages).length === 0) {
+      storage.removeItem(key);
+    } else {
+      storage.setItem(key, JSON.stringify(record));
+    }
+  } catch {
+    warnOnce();
+  }
+}
+
+export function removeDraftCameras(draftId: string): void {
+  const storage = getStorage();
+  if (!storage || !draftId) return;
+  try {
+    storage.removeItem(keyFor(draftId));
+  } catch {
+    // Nothing to do; persistence is best-effort.
+  }
+}
+
+/**
+ * Stored value -> a fresh Camera for the current viewport. When the viewport
+ * changed size, preserve the world point at the viewport centre rather than the
+ * top-left, so the user is looking at the same content. Zoom is never rescaled.
+ */
+export function toRestoredCamera(stored: StoredPageCamera, viewport: ViewportSize | null): Camera {
+  const zoom = clampZoom(stored.zoom);
+  const current = sanitizeViewport(viewport);
+  const original =
+    stored.vw !== undefined && stored.vh !== undefined
+      ? sanitizeViewport({ width: stored.vw, height: stored.vh })
+      : null;
+
+  if (
+    !current ||
+    !original ||
+    (current.width === original.width && current.height === original.height)
+  ) {
+    return { x: stored.x, y: stored.y, zoom };
+  }
+
+  const worldCx = (original.width / 2 - stored.x) / zoom;
+  const worldCy = (original.height / 2 - stored.y) / zoom;
+
+  return {
+    x: current.width / 2 - worldCx * zoom,
+    y: current.height / 2 - worldCy * zoom,
+    zoom,
+  };
+}

--- a/apps/web/src/pages/editor/components/left-panel/page-list.tsx
+++ b/apps/web/src/pages/editor/components/left-panel/page-list.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type * as Y from 'yjs';
 import { MoreHorizontal, Plus, Check, X } from 'lucide-react';
+import { useParams } from 'react-router-dom';
 import {
   addPage,
   getActivePageId,
+  getPages,
   observePages,
   removePage,
   renamePage,
@@ -20,12 +22,24 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { useEditorStore } from '@/stores/editor-store';
+import { applyCameraForPage, dropPendingCameraSave } from '@/pages/editor/lib/camera-session';
+import { removePageCamera } from '@/lib/camera-storage';
 
 interface PageListProps {
   ydoc: Y.Doc;
 }
 
-function switchToPage(ydoc: Y.Doc, pageId: string) {
+/**
+ * Stays synchronous: setActivePageId and the camera land in the same event
+ * handler batch, so the new page's first paint already has the right camera.
+ * Moving this into an effect would flash one frame of the outgoing camera.
+ */
+function switchToPage(
+  ydoc: Y.Doc,
+  pageId: string,
+  draftId: string | undefined,
+  inPreview: boolean,
+) {
   const switched = setActivePage(ydoc, pageId);
   if (!switched) return;
 
@@ -35,13 +49,21 @@ function switchToPage(ydoc: Y.Doc, pageId: string) {
   store.setEnteredGroupId(null);
   store.setHoveredId(null);
   store.setEditingTextId(null);
-  store.setCamera(DEFAULT_CAMERA);
+
+  if (draftId && !inPreview) {
+    applyCameraForPage(draftId, pageId, 'default', ydoc);
+  } else {
+    // Spread: the applied-camera identity marker must never alias the constant.
+    store.setCamera({ ...DEFAULT_CAMERA });
+  }
 }
 
 export function PageList({ ydoc }: PageListProps) {
+  const { draftId } = useParams<{ draftId: string }>();
   const [pages, setPages] = useState<PageData[]>([]);
   const activePageId = useEditorStore((s) => s.activePageId);
   const setActivePageId = useEditorStore((s) => s.setActivePageId);
+  const previewSnapshotId = useEditorStore((s) => s.previewSnapshotId);
   const [renamingPageId, setRenamingPageId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
 
@@ -59,17 +81,17 @@ export function PageList({ ydoc }: PageListProps) {
   const handleSwitchPage = useCallback(
     (pageId: string) => {
       if (pageId === activePageId) return;
-      switchToPage(ydoc, pageId);
+      switchToPage(ydoc, pageId, draftId, !!previewSnapshotId);
     },
-    [activePageId, ydoc],
+    [activePageId, ydoc, draftId, previewSnapshotId],
   );
 
   const handleAddPage = useCallback(() => {
     const nextId = addPage(ydoc);
-    switchToPage(ydoc, nextId);
+    switchToPage(ydoc, nextId, draftId, !!previewSnapshotId);
     setRenamingPageId(nextId);
     setRenameValue(`Page ${pages.length + 1}`);
-  }, [ydoc, pages]);
+  }, [ydoc, pages, draftId, previewSnapshotId]);
 
   const startRename = useCallback((page: PageData) => {
     setRenamingPageId(page.id);
@@ -94,16 +116,28 @@ export function PageList({ ydoc }: PageListProps) {
   const handleDeletePage = useCallback(
     (pageId: string) => {
       removePage(ydoc, pageId);
+
+      // Only the storage cleanup is preview-guarded: during preview `ydoc` is the
+      // snapshot doc while `draftId` is the real draft, and shared page ids mean
+      // unguarded cleanup would evict a still-existing live page's camera.
+      // Deletion itself must keep working in preview.
+      if (!previewSnapshotId && draftId && !getPages(ydoc).some((p) => p.id === pageId)) {
+        // Drop first: a pan on this page may still be pending, and the flush
+        // inside switchToPage's apply would otherwise resurrect the entry.
+        dropPendingCameraSave(pageId);
+        removePageCamera(draftId, pageId);
+      }
+
       const fallbackActive = getActivePageId(ydoc);
       if (!fallbackActive) {
         return;
       }
       setActivePageId(fallbackActive);
       if (activePageId === pageId || !activePageId) {
-        switchToPage(ydoc, fallbackActive);
+        switchToPage(ydoc, fallbackActive, draftId, !!previewSnapshotId);
       }
     },
-    [ydoc, activePageId, setActivePageId],
+    [ydoc, activePageId, setActivePageId, draftId, previewSnapshotId],
   );
 
   return (

--- a/apps/web/src/pages/editor/components/right-panel/zoom-controls.tsx
+++ b/apps/web/src/pages/editor/components/right-panel/zoom-controls.tsx
@@ -10,55 +10,14 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useEditorStore } from '@/stores/editor-store';
+import { getBounds, getCanvasViewportRect, fitCameraToBounds } from '../../lib/fit-camera';
 
-function getBounds(shapes: Array<{ x: number; y: number; width: number; height: number }>) {
-  if (shapes.length === 0) return null;
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-
-  for (const shape of shapes) {
-    minX = Math.min(minX, shape.x);
-    minY = Math.min(minY, shape.y);
-    maxX = Math.max(maxX, shape.x + shape.width);
-    maxY = Math.max(maxY, shape.y + shape.height);
-  }
-
-  return { minX, minY, maxX, maxY };
-}
-
-function getCanvasViewportRect(): DOMRect | null {
-  const canvas = document.querySelector('canvas');
-  if (!(canvas instanceof HTMLCanvasElement)) return null;
-  return canvas.getBoundingClientRect();
-}
-
-function fitCameraToBounds(
-  bounds: { minX: number; minY: number; maxX: number; maxY: number },
-  viewport: DOMRect,
-  padding: number,
-) {
-  const contentWidth = bounds.maxX - bounds.minX;
-  const contentHeight = bounds.maxY - bounds.minY;
-  if (contentWidth <= 0 || contentHeight <= 0) return null;
-
-  const availableWidth = Math.max(1, viewport.width - padding * 2);
-  const availableHeight = Math.max(1, viewport.height - padding * 2);
-  const zoom = Math.min(
-    256,
-    Math.max(0.02, Math.min(availableWidth / contentWidth, availableHeight / contentHeight)),
-  );
-
-  const centerX = (bounds.minX + bounds.maxX) / 2;
-  const centerY = (bounds.minY + bounds.maxY) / 2;
-
-  return {
-    x: viewport.width / 2 - centerX * zoom,
-    y: viewport.height / 2 - centerY * zoom,
-    zoom,
-  };
-}
+/**
+ * These controls have always allowed zooming further in than the ⇧1 fit
+ * shortcut (256 vs the shared FIT_MAX_ZOOM of 64). Passing it explicitly keeps
+ * that behaviour byte-for-byte while sharing one implementation.
+ */
+const ZOOM_CONTROLS_MAX_ZOOM = 256;
 
 interface ZoomControlsProps {
   ydoc: Y.Doc;
@@ -76,7 +35,7 @@ export function ZoomControls({ ydoc }: ZoomControlsProps) {
     if (!bounds) return;
     const viewport = getCanvasViewportRect();
     if (!viewport) return;
-    const next = fitCameraToBounds(bounds, viewport, 80);
+    const next = fitCameraToBounds(bounds, viewport, 80, ZOOM_CONTROLS_MAX_ZOOM);
     if (!next) return;
     setCamera(next);
   };
@@ -89,7 +48,7 @@ export function ZoomControls({ ydoc }: ZoomControlsProps) {
     if (!bounds) return;
     const viewport = getCanvasViewportRect();
     if (!viewport) return;
-    const next = fitCameraToBounds(bounds, viewport, 120);
+    const next = fitCameraToBounds(bounds, viewport, 120, ZOOM_CONTROLS_MAX_ZOOM);
     if (!next) return;
     setCamera(next);
   };

--- a/apps/web/src/pages/editor/hooks/use-camera-persistence.ts
+++ b/apps/web/src/pages/editor/hooks/use-camera-persistence.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import type * as Y from 'yjs';
+import type { WebsocketProvider } from 'y-websocket';
+import { useEditorStore } from '@/stores/editor-store';
+import { createCameraSession } from '../lib/camera-session';
+
+interface UseCameraPersistenceOptions {
+  draftId: string;
+  ydoc: Y.Doc;
+  provider: WebsocketProvider | null;
+}
+
+/**
+ * Records genuine user camera movement and persists it per (draft, page).
+ *
+ * Deliberately not keyed on `synced`: that flips on every reconnect, and tearing
+ * the session down each time would churn the pending map for no benefit. The
+ * provider instance survives reconnects, so the triple below is the real
+ * consistency signal.
+ */
+export function useCameraPersistence({
+  draftId,
+  ydoc,
+  provider,
+}: UseCameraPersistenceOptions): void {
+  useEffect(() => {
+    // EditorPage does not remount on a :draftId change and useYjs returns refs,
+    // so for one render draftId is new while ydoc/provider are still the old
+    // pair. Recording through that window would write into the wrong draft's key.
+    if (!draftId || !provider) return;
+    if (provider.roomname !== draftId || provider.doc !== ydoc) return;
+
+    const session = createCameraSession({ draftId, ydoc });
+
+    const unsubscribe = useEditorStore.subscribe((state, prev) => {
+      if (state.camera === prev.camera) return;
+      if (state.previewSnapshotId) return; // preview pans are ephemeral
+      session.record(state.camera);
+    });
+
+    const flush = () => session.flush();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flush();
+    };
+
+    window.addEventListener('pagehide', flush);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      unsubscribe();
+      // In-app navigation away is the most common save moment, and it fires no
+      // pagehide — the dispose flush covers it.
+      session.dispose();
+    };
+  }, [draftId, ydoc, provider]);
+}

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { PanelLeft, Upload, Eye, Keyboard, History } from 'lucide-react';
 import logoSvg from '@/assets/logo.svg';
@@ -21,7 +21,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { InlineEditableText } from '@/components/inline-editable-text';
 import { UserMenu } from '@/components/user-menu';
 import { getActivePageId, setActivePage } from '@draftila/engine';
-import { DEFAULT_CAMERA } from '@draftila/engine/camera';
 import { initUndoManager, destroyUndoManager } from '@draftila/engine/history';
 import { getMoveTool } from '@draftila/engine/tools/tool-manager';
 import { addShape } from '@draftila/engine/scene-graph';
@@ -36,7 +35,8 @@ import { RightPanel } from './components/right-panel';
 import { Canvas } from './components/canvas';
 import { useYjs } from './hooks/use-yjs';
 import { useKeyboard } from './hooks/use-keyboard';
-import { fitCameraToAllShapes } from './lib/fit-camera';
+import { useCameraPersistence } from './hooks/use-camera-persistence';
+import { applyCameraForPageEntry, invalidateCameraApplyKey } from './lib/camera-session';
 import { useAwareness } from './hooks/use-awareness';
 import { useThumbnail } from './hooks/use-thumbnail';
 import { useRpc } from './hooks/use-rpc';
@@ -93,6 +93,7 @@ export function EditorPage() {
   const previewSnapshotId = useEditorStore((s) => s.previewSnapshotId);
   const previewYdoc = useEditorStore((s) => s.previewYdoc);
   const lastPageIdRef = useRef<string | null>(null);
+  const prevPreviewRef = useRef<string | null>(null);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -178,16 +179,31 @@ export function EditorPage() {
   useKeyboard({ ydoc });
   useThumbnail(draftId ?? '', ydoc, synced);
   useRpc({ provider, ydoc, enabled: synced });
+  useCameraPersistence({ draftId: draftId ?? '', ydoc, provider });
 
   useEffect(() => {
     useEditorStore.getState().setReinitializeYjs(reinitialize);
     return () => useEditorStore.getState().setReinitializeYjs(null);
   }, [reinitialize]);
 
-  useEffect(() => {
-    if (!synced) return;
-    requestAnimationFrame(() => fitCameraToAllShapes(ydoc));
-  }, [synced, ydoc]);
+  // Single owner of "what camera does this page get on entry". A layout effect
+  // (not rAF) so the camera is applied before first paint: the canvas is
+  // CSS-sized, and reading its rect here forces the layout we need.
+  useLayoutEffect(() => {
+    const exitedPreview = prevPreviewRef.current !== null && previewSnapshotId === null;
+    prevPreviewRef.current = previewSnapshotId;
+    // Force a re-apply on preview exit, otherwise the dedupe key would match and
+    // a camera panned to inside preview would become the live session's camera.
+    if (exitedPreview) invalidateCameraApplyKey();
+
+    if (!draftId || !synced || previewSnapshotId) return;
+    if (!provider || provider.roomname !== draftId || provider.doc !== ydoc) return;
+
+    const pageId = getActivePageId(ydoc); // engine truth; activePageId is only a trigger
+    if (!pageId) return;
+
+    applyCameraForPageEntry(draftId, pageId, ydoc);
+  }, [synced, ydoc, draftId, provider, activePageId, previewSnapshotId]);
 
   useEffect(() => {
     const pageId = activePageId ?? getActivePageId(ydoc);
@@ -204,7 +220,7 @@ export function EditorPage() {
       store.setEnteredGroupId(null);
       store.setHoveredId(null);
       store.setEditingTextId(null);
-      store.setCamera(DEFAULT_CAMERA);
+      // Camera is owned by the page-entry layout effect above.
     }
     if (pageId) {
       lastPageIdRef.current = pageId;

--- a/apps/web/src/pages/editor/lib/camera-session.ts
+++ b/apps/web/src/pages/editor/lib/camera-session.ts
@@ -1,0 +1,203 @@
+import type * as Y from 'yjs';
+import type { Camera } from '@draftila/shared';
+import { getActivePageId } from '@draftila/engine';
+import { DEFAULT_CAMERA } from '@draftila/engine/camera';
+import {
+  loadPageCamera,
+  sanitizeViewport,
+  savePageCamera,
+  toRestoredCamera,
+  type ViewportSize,
+} from '../../../lib/camera-storage';
+import { useEditorStore } from '../../../stores/editor-store';
+import { computeFitCamera, getCanvasViewportRect } from './fit-camera';
+
+const SAVE_DEBOUNCE_MS = 500;
+
+function defaultGetViewport(): ViewportSize | null {
+  return sanitizeViewport(getCanvasViewportRect());
+}
+
+export interface CameraSessionOptions {
+  draftId: string;
+  ydoc: Y.Doc;
+  /** Injected so tests never need a DOM. */
+  getViewport?: () => ViewportSize | null;
+}
+
+export interface CameraSession {
+  /** Page id is derived internally from engine truth; (re)arms the trailing timer. */
+  record(camera: Camera): void;
+  /** Clears the timer and writes all pending entries. Touches neither the DOM nor the doc. */
+  flush(): void;
+  dispose(): void;
+}
+
+interface InternalCameraSession extends CameraSession {
+  drop(pageId: string): void;
+}
+
+interface PendingEntry {
+  camera: Camera;
+  viewport: ViewportSize | null;
+}
+
+let currentSession: InternalCameraSession | null = null;
+
+/**
+ * Identity marker for cameras this module applied, so the store subscription can
+ * tell a restore from genuine user movement. It must never alias a shared
+ * constant: DEFAULT_CAMERA is also the store's initial value, so aliasing it
+ * would swallow every future `setCamera(DEFAULT_CAMERA)` forever.
+ */
+let lastApplied: Camera | null = null;
+
+/**
+ * Drives both "already applied here, skip" and the 'fit'-vs-'default' choice.
+ * `ydoc` is part of the key because version restore rebuilds the doc under the
+ * same draftId with the same page ids — a (draftId, pageId) key would survive
+ * that swap and wrongly skip. `pageId` is nullable so the preview-exit contract
+ * can clear the page marker while keeping the (draftId, ydoc) context.
+ */
+let lastAppliedKey: { draftId: string; ydoc: Y.Doc; pageId: string | null } | null = null;
+
+export function createCameraSession(opts: CameraSessionOptions): CameraSession {
+  const { draftId, ydoc } = opts;
+  const getViewport = opts.getViewport ?? defaultGetViewport;
+  const pending = new Map<string, PendingEntry>();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimer(): void {
+    if (timer === null) return;
+    clearTimeout(timer);
+    timer = null;
+  }
+
+  const session: InternalCameraSession = {
+    record(camera) {
+      if (camera === lastApplied) return;
+
+      // Engine truth, never the store: with the left panel closed the store's
+      // activePageId can stay pinned to a previous draft's page for a whole
+      // session, which would silently persist nothing.
+      const pageId = getActivePageId(ydoc);
+      if (!pageId) return;
+
+      const viewport = getViewport();
+      pending.set(pageId, {
+        camera,
+        // A transient null (canvas mid-layout) must not erase a good reading.
+        viewport: viewport ?? pending.get(pageId)?.viewport ?? null,
+      });
+
+      clearTimer();
+      timer = setTimeout(() => {
+        timer = null;
+        session.flush();
+      }, SAVE_DEBOUNCE_MS);
+    },
+
+    flush() {
+      clearTimer();
+      if (pending.size === 0) return;
+      for (const [pageId, entry] of pending) {
+        savePageCamera(draftId, pageId, entry.camera, entry.viewport);
+      }
+      pending.clear();
+    },
+
+    drop(pageId) {
+      pending.delete(pageId);
+    },
+
+    dispose() {
+      session.flush();
+      // Only the live session may clear the slot; an unconditional clear would
+      // let a stale cleanup silence all future saves.
+      if (currentSession === session) currentSession = null;
+    },
+  };
+
+  currentSession?.dispose();
+  currentSession = session;
+  return session;
+}
+
+export function flushPendingCameraSaves(): void {
+  currentSession?.flush();
+}
+
+/** Discard a pending entry without writing it (page deletion). */
+export function dropPendingCameraSave(pageId: string): void {
+  currentSession?.drop(pageId);
+}
+
+/** Injection seam so tests need no DOM. */
+export interface CameraApplyDeps {
+  getViewport?: () => ViewportSize | null;
+  computeFit?: (ydoc: Y.Doc) => Camera | null;
+}
+
+export function applyCameraForPage(
+  draftId: string,
+  pageId: string,
+  fallback: 'fit' | 'default',
+  ydoc: Y.Doc,
+  deps: CameraApplyDeps = {},
+): void {
+  const getViewport = deps.getViewport ?? defaultGetViewport;
+  const computeFit = deps.computeFit ?? computeFitCamera;
+
+  // Commit outgoing movement before reading, so switching away and back within
+  // the debounce window restores the panned position rather than a stale one.
+  flushPendingCameraSaves();
+
+  const stored = loadPageCamera(draftId, pageId);
+  const camera: Camera = stored
+    ? toRestoredCamera(stored, getViewport())
+    : fallback === 'fit'
+      ? (computeFit(ydoc) ?? { ...DEFAULT_CAMERA })
+      : { ...DEFAULT_CAMERA };
+
+  lastApplied = camera;
+  lastAppliedKey = { draftId, ydoc, pageId };
+  useEditorStore.getState().setCamera(camera);
+}
+
+export function isCameraAppliedFor(draftId: string, pageId: string, ydoc: Y.Doc): boolean {
+  return (
+    lastAppliedKey !== null &&
+    lastAppliedKey.draftId === draftId &&
+    lastAppliedKey.ydoc === ydoc &&
+    lastAppliedKey.pageId === pageId
+  );
+}
+
+/**
+ * Effect-driven page entry: decides skip / 'default' / 'fit' itself, so duplicate
+ * triggers (store corrections, StrictMode, reconnects) are free.
+ */
+export function applyCameraForPageEntry(
+  draftId: string,
+  pageId: string,
+  ydoc: Y.Doc,
+  deps?: CameraApplyDeps,
+): void {
+  if (isCameraAppliedFor(draftId, pageId, ydoc)) return;
+
+  const sameContext =
+    lastAppliedKey !== null && lastAppliedKey.draftId === draftId && lastAppliedKey.ydoc === ydoc;
+
+  applyCameraForPage(draftId, pageId, sameContext ? 'default' : 'fit', ydoc, deps);
+}
+
+/**
+ * Clears the applied-page marker while preserving the (draftId, ydoc) context, so
+ * the next entry re-applies with 'default' semantics instead of skipping. Used on
+ * preview exit: without it, a camera panned to inside preview would silently
+ * become the live session's camera.
+ */
+export function invalidateCameraApplyKey(): void {
+  if (lastAppliedKey === null) return;
+  lastAppliedKey = { ...lastAppliedKey, pageId: null };
+}

--- a/apps/web/src/pages/editor/lib/fit-camera.ts
+++ b/apps/web/src/pages/editor/lib/fit-camera.ts
@@ -1,4 +1,5 @@
 import type * as Y from 'yjs';
+import type { Camera } from '@draftila/shared';
 import { getAllShapes } from '@draftila/engine/scene-graph';
 import { MIN_ZOOM } from '@draftila/engine/camera';
 import { useEditorStore } from '@/stores/editor-store';
@@ -10,6 +11,12 @@ interface Bounds {
   minY: number;
   maxX: number;
   maxY: number;
+}
+
+/** Structural subset of DOMRect, so callers can pass a plain size. */
+interface ViewportRect {
+  width: number;
+  height: number;
 }
 
 export function getBounds(
@@ -35,7 +42,12 @@ export function getCanvasViewportRect(): DOMRect | null {
   return canvas.getBoundingClientRect();
 }
 
-export function fitCameraToBounds(bounds: Bounds, viewport: DOMRect, padding: number) {
+export function fitCameraToBounds(
+  bounds: Bounds,
+  viewport: ViewportRect,
+  padding: number,
+  maxZoom = FIT_MAX_ZOOM,
+) {
   const contentWidth = bounds.maxX - bounds.minX;
   const contentHeight = bounds.maxY - bounds.minY;
   if (contentWidth <= 0 || contentHeight <= 0) return null;
@@ -43,7 +55,7 @@ export function fitCameraToBounds(bounds: Bounds, viewport: DOMRect, padding: nu
   const availableWidth = Math.max(1, viewport.width - padding * 2);
   const availableHeight = Math.max(1, viewport.height - padding * 2);
   const zoom = Math.min(
-    FIT_MAX_ZOOM,
+    maxZoom,
     Math.max(MIN_ZOOM, Math.min(availableWidth / contentWidth, availableHeight / contentHeight)),
   );
 
@@ -57,13 +69,24 @@ export function fitCameraToBounds(bounds: Bounds, viewport: DOMRect, padding: nu
   };
 }
 
-export function fitCameraToAllShapes(ydoc: Y.Doc, padding = 80) {
+/**
+ * Pure compute: the camera that would fit all visible shapes, or null when there
+ * is nothing to fit (no shapes, no laid-out canvas, or degenerate bounds).
+ * Callers must handle null rather than leaving the camera untouched — the editor
+ * store is a module singleton, so "do nothing" silently keeps the previous
+ * draft's camera.
+ */
+export function computeFitCamera(ydoc: Y.Doc, padding = 80): Camera | null {
   const shapes = getAllShapes(ydoc).filter((shape) => shape.visible);
   const bounds = getBounds(shapes);
-  if (!bounds) return;
+  if (!bounds) return null;
   const viewport = getCanvasViewportRect();
-  if (!viewport) return;
-  const next = fitCameraToBounds(bounds, viewport, padding);
+  if (!viewport) return null;
+  return fitCameraToBounds(bounds, viewport, padding);
+}
+
+export function fitCameraToAllShapes(ydoc: Y.Doc, padding = 80) {
+  const next = computeFitCamera(ydoc, padding);
   if (!next) return;
   useEditorStore.getState().setCamera(next);
 }

--- a/apps/web/src/pages/editor/lib/fit-camera.ts
+++ b/apps/web/src/pages/editor/lib/fit-camera.ts
@@ -39,6 +39,17 @@ export function getBounds(
 export function getCanvasViewportRect(): DOMRect | null {
   const canvas = document.querySelector('canvas');
   if (!(canvas instanceof HTMLCanvasElement)) return null;
+
+  // Measure the container, which is what the canvas is actually sized from
+  // (see `updateSize` in use-canvas). Until that effect runs the canvas element
+  // still reports its 300x150 intrinsic default, which would silently produce a
+  // wrong zoom-to-fit and a shifted camera restore on first mount.
+  const container = canvas.parentElement;
+  if (container) {
+    const rect = container.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) return rect;
+  }
+
   return canvas.getBoundingClientRect();
 }
 

--- a/apps/web/tests/camera-session.test.ts
+++ b/apps/web/tests/camera-session.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import * as Y from 'yjs';
+import { addPage, removePage, setActivePage } from '@draftila/engine';
+import { DEFAULT_CAMERA } from '@draftila/engine/camera';
+import {
+  applyCameraForPage,
+  applyCameraForPageEntry,
+  createCameraSession,
+  dropPendingCameraSave,
+  invalidateCameraApplyKey,
+  type CameraApplyDeps,
+  type CameraSession,
+} from '../src/pages/editor/lib/camera-session';
+import { loadPageCamera } from '../src/lib/camera-storage';
+import { useEditorStore } from '../src/stores/editor-store';
+import { MemoryStorage } from './setup';
+
+const VIEWPORT = { width: 1200, height: 800 };
+
+/** Deps that never touch the DOM. `computeFit` counts calls so tests can assert the branch taken. */
+function makeDeps(fit: { x: number; y: number; zoom: number } | null = null) {
+  const calls = { computeFit: 0 };
+  const deps: CameraApplyDeps = {
+    getViewport: () => VIEWPORT,
+    computeFit: () => {
+      calls.computeFit++;
+      return fit ? { ...fit } : null;
+    },
+  };
+  return { deps, calls };
+}
+
+/**
+ * The production wiring lives in the hook, so each test reproduces it: record()
+ * is only ever reached through this subscription.
+ */
+function wire(session: CameraSession): () => void {
+  return useEditorStore.subscribe((state, prev) => {
+    if (state.camera === prev.camera) return;
+    if (state.previewSnapshotId) return;
+    session.record(state.camera);
+  });
+}
+
+/** `addPage` rather than `ensureDefaultPage`: the latter reads nested types before
+ *  integrating them, which makes Yjs log a warning on every call. */
+function makeDoc(): { ydoc: Y.Doc; pageId: string } {
+  const ydoc = new Y.Doc();
+  const pageId = addPage(ydoc);
+  setActivePage(ydoc, pageId);
+  return { ydoc, pageId };
+}
+
+beforeEach(() => {
+  globalThis.localStorage = new MemoryStorage();
+  // Reset the module-level apply key by applying into a throwaway context.
+  const { ydoc, pageId } = makeDoc();
+  applyCameraForPage('__reset__', pageId, 'default', ydoc, makeDeps().deps);
+  useEditorStore.getState().setActivePageId(null);
+});
+
+describe('identity suppression', () => {
+  test('an applied camera is not recorded, but an external one is', () => {
+    const { ydoc, pageId } = makeDoc();
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(session);
+
+    applyCameraForPage('d1', pageId, 'default', ydoc, makeDeps().deps);
+    session.flush();
+    expect(loadPageCamera('d1', pageId)).toBeNull();
+
+    useEditorStore.getState().setCamera({ x: 7, y: 8, zoom: 3 });
+    session.flush();
+    expect(loadPageCamera('d1', pageId)?.x).toBe(7);
+
+    unsubscribe();
+    session.dispose();
+  });
+
+  test('repeated default fallbacks never poison the shared DEFAULT_CAMERA constant', () => {
+    const { ydoc, pageId } = makeDoc();
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(session);
+
+    for (let i = 0; i < 3; i++) {
+      applyCameraForPage('d1', pageId, 'default', ydoc, makeDeps().deps);
+    }
+
+    // A genuine user action that happens to land on the default camera.
+    useEditorStore.getState().setCamera({ ...DEFAULT_CAMERA });
+    session.flush();
+
+    const stored = loadPageCamera('d1', pageId);
+    expect(stored).not.toBeNull();
+    expect(stored?.zoom).toBe(DEFAULT_CAMERA.zoom);
+
+    unsubscribe();
+    session.dispose();
+  });
+});
+
+describe('entry logic', () => {
+  test('a fresh context fits; null fit falls back to the default camera by value', () => {
+    const { ydoc, pageId } = makeDoc();
+    const { deps, calls } = makeDeps();
+
+    applyCameraForPageEntry('d1', pageId, ydoc, deps);
+
+    expect(calls.computeFit).toBe(1);
+    const camera = useEditorStore.getState().camera;
+    expect(camera).toEqual(DEFAULT_CAMERA);
+    expect(camera).not.toBe(DEFAULT_CAMERA);
+  });
+
+  test('a new page in the same context uses default, not fit', () => {
+    const { ydoc, pageId } = makeDoc();
+    const second = addPage(ydoc);
+
+    applyCameraForPageEntry('d1', pageId, ydoc, makeDeps({ x: 1, y: 1, zoom: 4 }).deps);
+
+    const { deps, calls } = makeDeps({ x: 1, y: 1, zoom: 4 });
+    applyCameraForPageEntry('d1', second, ydoc, deps);
+
+    expect(calls.computeFit).toBe(0);
+    expect(useEditorStore.getState().camera).toEqual(DEFAULT_CAMERA);
+  });
+
+  test('an exact repeat is skipped', () => {
+    const { ydoc, pageId } = makeDoc();
+    applyCameraForPageEntry('d1', pageId, ydoc, makeDeps({ x: 5, y: 5, zoom: 2 }).deps);
+    const applied = useEditorStore.getState().camera;
+
+    const { deps, calls } = makeDeps({ x: 9, y: 9, zoom: 9 });
+    applyCameraForPageEntry('d1', pageId, ydoc, deps);
+
+    expect(calls.computeFit).toBe(0);
+    expect(useEditorStore.getState().camera).toBe(applied);
+  });
+
+  test('the same draft with a new doc fits again (version restore)', () => {
+    const first = makeDoc();
+    applyCameraForPageEntry('d1', first.pageId, first.ydoc, makeDeps({ x: 1, y: 1, zoom: 2 }).deps);
+
+    // Version restore rebuilds the doc under the same draftId, preserving page ids.
+    const restored = new Y.Doc();
+    const restoredPageId = addPage(restored);
+    setActivePage(restored, restoredPageId);
+
+    const { deps, calls } = makeDeps({ x: 3, y: 3, zoom: 5 });
+    applyCameraForPageEntry('d1', restoredPageId, restored, deps);
+
+    expect(calls.computeFit).toBe(1);
+    expect(useEditorStore.getState().camera).toEqual({ x: 3, y: 3, zoom: 5 });
+  });
+
+  test('after invalidation an exact repeat re-applies with default, not fit', () => {
+    const { ydoc, pageId } = makeDoc();
+    applyCameraForPageEntry('d1', pageId, ydoc, makeDeps({ x: 1, y: 1, zoom: 2 }).deps);
+
+    // Stands in for a pan made inside version preview.
+    useEditorStore.getState().setCamera({ x: 999, y: 999, zoom: 9 });
+
+    invalidateCameraApplyKey();
+
+    const { deps, calls } = makeDeps({ x: 4, y: 4, zoom: 4 });
+    applyCameraForPageEntry('d1', pageId, ydoc, deps);
+
+    expect(calls.computeFit).toBe(0); // 'default', not 'fit'
+    expect(useEditorStore.getState().camera).toEqual(DEFAULT_CAMERA); // preview pan discarded
+  });
+});
+
+describe('recording', () => {
+  test('uses engine truth for the page id, not the store', () => {
+    const { ydoc, pageId } = makeDoc();
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(session);
+
+    // The store id can stay pinned to a previous draft's page for a whole session.
+    useEditorStore.getState().setActivePageId('stale-page-from-another-draft');
+
+    useEditorStore.getState().setCamera({ x: 42, y: 43, zoom: 1 });
+    session.flush();
+
+    expect(loadPageCamera('d1', pageId)?.x).toBe(42);
+    expect(loadPageCamera('d1', 'stale-page-from-another-draft')).toBeNull();
+
+    unsubscribe();
+    session.dispose();
+  });
+
+  test('captures the viewport per record and ignores transient nulls', () => {
+    const { ydoc, pageId } = makeDoc();
+    let viewport: { width: number; height: number } | null = { width: 1200, height: 800 };
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => viewport });
+    const unsubscribe = wire(session);
+
+    useEditorStore.getState().setCamera({ x: 1, y: 1, zoom: 1 });
+
+    viewport = null; // canvas mid-layout
+    useEditorStore.getState().setCamera({ x: 2, y: 2, zoom: 1 });
+    session.flush();
+    expect(loadPageCamera('d1', pageId)?.vw).toBe(1200);
+
+    viewport = { width: 1440, height: 800 }; // left panel toggled
+    useEditorStore.getState().setCamera({ x: 3, y: 3, zoom: 1 });
+    session.flush();
+    expect(loadPageCamera('d1', pageId)?.vw).toBe(1440);
+
+    unsubscribe();
+    session.dispose();
+  });
+});
+
+describe('flush semantics', () => {
+  test('flush drains the map and clears the timer', async () => {
+    const { ydoc, pageId } = makeDoc();
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(session);
+
+    useEditorStore.getState().setCamera({ x: 11, y: 11, zoom: 1 });
+    session.flush();
+    expect(loadPageCamera('d1', pageId)?.x).toBe(11);
+
+    // A surviving timer would fire against an empty map; nothing should change.
+    localStorage.clear();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(loadPageCamera('d1', pageId)).toBeNull();
+
+    unsubscribe();
+    session.dispose();
+  });
+
+  test('applying commits a pending pan before reading (quick switch back)', () => {
+    const { ydoc, pageId } = makeDoc();
+    const other = addPage(ydoc);
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(session);
+
+    // Pan page 1, then switch away and back inside the debounce window.
+    useEditorStore.getState().setCamera({ x: 77, y: 78, zoom: 3 });
+    setActivePage(ydoc, other);
+    applyCameraForPage('d1', other, 'default', ydoc, makeDeps().deps);
+
+    setActivePage(ydoc, pageId);
+    applyCameraForPage('d1', pageId, 'default', ydoc, makeDeps().deps);
+
+    expect(useEditorStore.getState().camera.x).toBe(77);
+
+    unsubscribe();
+    session.dispose();
+  });
+});
+
+describe('deletion', () => {
+  test('a dropped pending entry is never resurrected by a later flush', () => {
+    const { ydoc, pageId } = makeDoc();
+    const other = addPage(ydoc);
+    const session = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(session);
+
+    useEditorStore.getState().setCamera({ x: 5, y: 5, zoom: 2 });
+
+    removePage(ydoc, pageId);
+    dropPendingCameraSave(pageId);
+
+    setActivePage(ydoc, other);
+    applyCameraForPage('d1', other, 'default', ydoc, makeDeps().deps); // flushes internally
+    session.flush();
+
+    expect(loadPageCamera('d1', pageId)).toBeNull();
+
+    unsubscribe();
+    session.dispose();
+  });
+});
+
+describe('slot ownership', () => {
+  test('creating a session disposes the previous one and flushes its pendings', () => {
+    const { ydoc, pageId } = makeDoc();
+    const first = createCameraSession({ ydoc, draftId: 'd1', getViewport: () => VIEWPORT });
+    const unsubscribe = wire(first);
+
+    useEditorStore.getState().setCamera({ x: 21, y: 22, zoom: 1 });
+    unsubscribe();
+
+    const second = createCameraSession({ ydoc, draftId: 'd2', getViewport: () => VIEWPORT });
+    expect(loadPageCamera('d1', pageId)?.x).toBe(21);
+
+    // A stale dispose must not null the live slot: d2 must still flush.
+    first.dispose();
+    const unsubscribe2 = wire(second);
+    useEditorStore.getState().setCamera({ x: 31, y: 32, zoom: 1 });
+    second.flush();
+    expect(loadPageCamera('d2', pageId)?.x).toBe(31);
+
+    unsubscribe2();
+    second.dispose();
+  });
+});

--- a/apps/web/tests/camera-storage.test.ts
+++ b/apps/web/tests/camera-storage.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import {
+  CAMERA_STORAGE_PREFIX,
+  MAX_TRACKED_DRAFTS,
+  MAX_TRACKED_PAGES_PER_DRAFT,
+  loadPageCamera,
+  parseDraftRecord,
+  prunePages,
+  removeDraftCameras,
+  removePageCamera,
+  sanitizeStoredCamera,
+  sanitizeViewport,
+  savePageCamera,
+  toRestoredCamera,
+  type DraftCameraRecord,
+} from '../src/lib/camera-storage';
+import { MemoryStorage } from './setup';
+
+const CAM = { x: 10, y: 20, zoom: 2 };
+
+function keyFor(draftId: string): string {
+  return `${CAMERA_STORAGE_PREFIX}${draftId}`;
+}
+
+function rawRecord(draftId: string): DraftCameraRecord | null {
+  return parseDraftRecord(localStorage.getItem(keyFor(draftId)));
+}
+
+function cameraKeyCount(): number {
+  let count = 0;
+  for (let i = 0; i < localStorage.length; i++) {
+    if (localStorage.key(i)?.startsWith(CAMERA_STORAGE_PREFIX)) count++;
+  }
+  return count;
+}
+
+beforeEach(() => {
+  globalThis.localStorage = new MemoryStorage();
+});
+
+describe('sanitizeStoredCamera', () => {
+  test('rejects non-finite, missing and non-numeric fields', () => {
+    expect(sanitizeStoredCamera(null)).toBeNull();
+    expect(sanitizeStoredCamera('nope')).toBeNull();
+    expect(sanitizeStoredCamera({ x: NaN, y: 0, zoom: 1 })).toBeNull();
+    expect(sanitizeStoredCamera({ x: Infinity, y: 0, zoom: 1 })).toBeNull();
+    expect(sanitizeStoredCamera({ x: '0', y: 0, zoom: 1 })).toBeNull();
+    expect(sanitizeStoredCamera({ y: 0, zoom: 1 })).toBeNull();
+  });
+
+  test('clamps zoom into [MIN_ZOOM, MAX_ZOOM]', () => {
+    expect(sanitizeStoredCamera({ x: 0, y: 0, zoom: 1e9 })?.zoom).toBe(256);
+    expect(sanitizeStoredCamera({ x: 0, y: 0, zoom: 1e-9 })?.zoom).toBe(0.02);
+  });
+
+  test('rejects absurd offsets but keeps entries with invalid viewports', () => {
+    expect(sanitizeStoredCamera({ x: 1e11, y: 0, zoom: 1 })).toBeNull();
+    const kept = sanitizeStoredCamera({ x: 1, y: 2, zoom: 1, vw: 0, vh: -5 });
+    expect(kept).not.toBeNull();
+    expect(kept?.vw).toBeUndefined();
+    expect(kept?.vh).toBeUndefined();
+  });
+
+  test('coerces a non-finite timestamp to 0', () => {
+    expect(sanitizeStoredCamera({ x: 0, y: 0, zoom: 1, t: NaN })?.t).toBe(0);
+  });
+});
+
+describe('sanitizeViewport', () => {
+  test('rejects degenerate and non-finite sizes', () => {
+    expect(sanitizeViewport({ width: 0, height: 0 })).toBeNull();
+    expect(sanitizeViewport({ width: -1, height: 10 })).toBeNull();
+    expect(sanitizeViewport({ width: NaN, height: 10 })).toBeNull();
+    expect(sanitizeViewport(null)).toBeNull();
+    expect(sanitizeViewport({ width: 800, height: 600 })).toEqual({ width: 800, height: 600 });
+  });
+});
+
+describe('parseDraftRecord', () => {
+  test('rejects bad JSON, wrong version and malformed pages', () => {
+    expect(parseDraftRecord(null)).toBeNull();
+    expect(parseDraftRecord('{ not json')).toBeNull();
+    expect(parseDraftRecord(JSON.stringify({ v: 2, t: 1, pages: {} }))).toBeNull();
+    expect(parseDraftRecord(JSON.stringify({ v: 1, t: 1, pages: [] }))).toBeNull();
+    expect(parseDraftRecord(JSON.stringify({ v: 1, t: 1 }))).toBeNull();
+  });
+
+  test('drops individually corrupt page entries but keeps valid ones', () => {
+    const raw = JSON.stringify({
+      v: 1,
+      t: 5,
+      pages: { good: { x: 1, y: 2, zoom: 1, t: 5 }, bad: { x: NaN, y: 0, zoom: 1, t: 5 } },
+    });
+    const record = parseDraftRecord(raw);
+    expect(Object.keys(record?.pages ?? {})).toEqual(['good']);
+  });
+});
+
+describe('save/load roundtrip', () => {
+  test('restores the same camera and viewport', () => {
+    savePageCamera('d1', 'p1', CAM, { width: 800, height: 600 });
+    const stored = loadPageCamera('d1', 'p1');
+    expect(stored?.x).toBe(10);
+    expect(stored?.y).toBe(20);
+    expect(stored?.zoom).toBe(2);
+    expect(stored?.vw).toBe(800);
+    expect(stored?.vh).toBe(600);
+    expect(typeof stored?.t).toBe('number');
+  });
+
+  test('a degenerate viewport stores no vw/vh', () => {
+    savePageCamera('d1', 'p1', CAM, { width: 0, height: 0 });
+    const stored = loadPageCamera('d1', 'p1');
+    expect(stored).not.toBeNull();
+    expect(stored?.vw).toBeUndefined();
+  });
+
+  test('unknown draft or page reads back null', () => {
+    savePageCamera('d1', 'p1', CAM, null);
+    expect(loadPageCamera('d1', 'other')).toBeNull();
+    expect(loadPageCamera('other', 'p1')).toBeNull();
+  });
+
+  test('read-merge-write leaves sibling pages intact', () => {
+    savePageCamera('d1', 'p1', CAM, null);
+    savePageCamera('d1', 'p2', { x: -5, y: -6, zoom: 0.5 }, null);
+    expect(loadPageCamera('d1', 'p1')?.x).toBe(10);
+    expect(loadPageCamera('d1', 'p2')?.x).toBe(-5);
+  });
+});
+
+describe('page LRU', () => {
+  test('evicts the oldest entry past the cap', () => {
+    const record: DraftCameraRecord = { v: 1, t: 0, pages: {} };
+    for (let i = 0; i < MAX_TRACKED_PAGES_PER_DRAFT + 1; i++) {
+      record.pages[`p${i}`] = { x: 0, y: 0, zoom: 1, t: i };
+    }
+    const pruned = prunePages(record, MAX_TRACKED_PAGES_PER_DRAFT, 'p40');
+    expect(Object.keys(pruned.pages)).toHaveLength(MAX_TRACKED_PAGES_PER_DRAFT);
+    expect(pruned.pages['p0']).toBeUndefined();
+    expect(pruned.pages['p40']).toBeDefined();
+  });
+
+  test('the just-written page survives when every timestamp is identical', () => {
+    // Reachable in production: one flush writes every pending entry in one task.
+    const record: DraftCameraRecord = { v: 1, t: 0, pages: {} };
+    for (let i = 0; i < MAX_TRACKED_PAGES_PER_DRAFT + 1; i++) {
+      record.pages[`p${i}`] = { x: 0, y: 0, zoom: 1, t: 1000 };
+    }
+    const pruned = prunePages(record, MAX_TRACKED_PAGES_PER_DRAFT, 'p0');
+    expect(Object.keys(pruned.pages)).toHaveLength(MAX_TRACKED_PAGES_PER_DRAFT);
+    expect(pruned.pages['p0']).toBeDefined();
+  });
+});
+
+describe('draft LRU', () => {
+  test('creating one key past the cap evicts down to exactly the cap, keeping the new key', () => {
+    for (let i = 0; i < MAX_TRACKED_DRAFTS + 1; i++) {
+      savePageCamera(`d${i}`, 'p1', CAM, null);
+    }
+    expect(cameraKeyCount()).toBe(MAX_TRACKED_DRAFTS);
+    // Tight loop ⇒ identical Date.now(); survival must not depend on timestamps.
+    expect(loadPageCamera(`d${MAX_TRACKED_DRAFTS}`, 'p1')).not.toBeNull();
+  });
+
+  test('leaves unrelated draftila keys untouched', () => {
+    localStorage.setItem('draftila:rulersVisible', 'true');
+    for (let i = 0; i < MAX_TRACKED_DRAFTS + 5; i++) {
+      savePageCamera(`d${i}`, 'p1', CAM, null);
+    }
+    expect(localStorage.getItem('draftila:rulersVisible')).toBe('true');
+  });
+
+  test('re-saving an existing key runs no cross-draft sweep', () => {
+    savePageCamera('d1', 'p1', CAM, null);
+
+    let enumerations = 0;
+    const storage = localStorage;
+    globalThis.localStorage = new Proxy(storage, {
+      get(target, prop, receiver) {
+        if (prop === 'length' || prop === 'key') enumerations++;
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Storage;
+
+    savePageCamera('d1', 'p2', CAM, null);
+    expect(enumerations).toBe(0);
+  });
+
+  test('an existing-but-corrupt key does not trigger the sweep', () => {
+    localStorage.setItem(keyFor('d1'), 'garbage');
+
+    let enumerations = 0;
+    const storage = localStorage;
+    globalThis.localStorage = new Proxy(storage, {
+      get(target, prop, receiver) {
+        if (prop === 'length' || prop === 'key') enumerations++;
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Storage;
+
+    savePageCamera('d1', 'p1', CAM, null);
+    expect(enumerations).toBe(0);
+    expect(loadPageCamera('d1', 'p1')).not.toBeNull();
+  });
+
+  test('a corrupt key is evicted first and the sweep terminates', () => {
+    localStorage.setItem(keyFor('corrupt'), 'not json at all');
+    for (let i = 0; i < MAX_TRACKED_DRAFTS; i++) {
+      savePageCamera(`d${i}`, 'p1', CAM, null);
+    }
+    expect(localStorage.getItem(keyFor('corrupt'))).toBeNull();
+    expect(cameraKeyCount()).toBe(MAX_TRACKED_DRAFTS);
+  });
+});
+
+describe('removal', () => {
+  test('removes one entry, and the whole key once it was the last', () => {
+    savePageCamera('d1', 'p1', CAM, null);
+    savePageCamera('d1', 'p2', CAM, null);
+
+    removePageCamera('d1', 'p1');
+    expect(loadPageCamera('d1', 'p1')).toBeNull();
+    expect(loadPageCamera('d1', 'p2')).not.toBeNull();
+
+    removePageCamera('d1', 'p2');
+    expect(localStorage.getItem(keyFor('d1'))).toBeNull();
+  });
+
+  test('removeDraftCameras drops the key', () => {
+    savePageCamera('d1', 'p1', CAM, null);
+    removeDraftCameras('d1');
+    expect(localStorage.getItem(keyFor('d1'))).toBeNull();
+  });
+});
+
+describe('quota handling', () => {
+  function quotaError(): Error {
+    const error = new Error('quota');
+    error.name = 'QuotaExceededError';
+    return error;
+  }
+
+  test('frees the stalest draft and retries, without throwing', () => {
+    savePageCamera('old', 'p1', CAM, null);
+    const record = rawRecord('old')!;
+    localStorage.setItem(keyFor('old'), JSON.stringify({ ...record, t: 1 }));
+    savePageCamera('newer', 'p1', CAM, null);
+
+    const inner = localStorage;
+    let rejectOnce = true;
+    globalThis.localStorage = new Proxy(inner, {
+      get(target, prop, receiver) {
+        if (prop === 'setItem') {
+          return (key: string, value: string) => {
+            if (rejectOnce && key === keyFor('fresh')) {
+              rejectOnce = false;
+              throw quotaError();
+            }
+            target.setItem(key, value);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Storage;
+
+    expect(() => savePageCamera('fresh', 'p1', CAM, null)).not.toThrow();
+    expect(inner.getItem(keyFor('old'))).toBeNull(); // stalest freed
+    expect(inner.getItem(keyFor('newer'))).not.toBeNull();
+    expect(inner.getItem(keyFor('fresh'))).not.toBeNull();
+  });
+
+  test('a persistently throwing setItem stays silent', () => {
+    globalThis.localStorage = new Proxy(new MemoryStorage(), {
+      get(target, prop, receiver) {
+        if (prop === 'setItem') {
+          return () => {
+            throw quotaError();
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Storage;
+
+    expect(() => savePageCamera('d1', 'p1', CAM, null)).not.toThrow();
+  });
+});
+
+describe('storage unavailable', () => {
+  test('every entry point no-ops rather than throwing', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('blocked');
+      },
+    });
+
+    expect(loadPageCamera('d1', 'p1')).toBeNull();
+    expect(() => savePageCamera('d1', 'p1', CAM, null)).not.toThrow();
+    expect(() => removePageCamera('d1', 'p1')).not.toThrow();
+    expect(() => removeDraftCameras('d1')).not.toThrow();
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      writable: true,
+      value: new MemoryStorage(),
+    });
+  });
+});
+
+describe('toRestoredCamera', () => {
+  test('preserves the world point at the viewport centre across a resize', () => {
+    const stored = { x: -500, y: -400, zoom: 2, vw: 1000, vh: 800, t: 0 };
+    const restored = toRestoredCamera(stored, { width: 1400, height: 900 });
+
+    const worldCx = (1000 / 2 - -500) / 2;
+    const worldCy = (800 / 2 - -400) / 2;
+    expect(restored.x).toBeCloseTo(1400 / 2 - worldCx * 2, 10);
+    expect(restored.y).toBeCloseTo(900 / 2 - worldCy * 2, 10);
+    expect(restored.zoom).toBe(2);
+  });
+
+  test('passes through when the viewport is unchanged, missing or degenerate', () => {
+    const stored = { x: -500, y: -400, zoom: 2, vw: 1000, vh: 800, t: 0 };
+    expect(toRestoredCamera(stored, { width: 1000, height: 800 })).toEqual({
+      x: -500,
+      y: -400,
+      zoom: 2,
+    });
+    expect(toRestoredCamera(stored, { width: 0, height: 0 }).x).toBe(-500);
+    expect(toRestoredCamera({ x: 1, y: 2, zoom: 1, t: 0 }, { width: 900, height: 900 })).toEqual({
+      x: 1,
+      y: 2,
+      zoom: 1,
+    });
+  });
+
+  test('clamps the restored zoom', () => {
+    expect(toRestoredCamera({ x: 0, y: 0, zoom: 5000, t: 0 }, null).zoom).toBe(256);
+  });
+});

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -1,0 +1,36 @@
+/**
+ * Preloaded (not imported per-file) because `editor-store.ts` reads localStorage
+ * at module scope, and the session tests import it transitively — the shim has to
+ * exist before any module initialises.
+ *
+ * No DOM shim is needed: everything under test takes its DOM reads by injection.
+ */
+export class MemoryStorage implements Storage {
+  private entries = new Map<string, string>();
+
+  get length(): number {
+    return this.entries.size;
+  }
+
+  key(index: number): string | null {
+    return [...this.entries.keys()][index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.entries.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.entries.set(key, String(value));
+  }
+
+  removeItem(key: string): void {
+    this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+globalThis.localStorage = new MemoryStorage();

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -182,6 +182,10 @@ if [ "$failed" -eq 0 ]; then
 fi
 
 if [ "$failed" -eq 0 ]; then
+  run_step "Web tests" bun run --filter @draftila/web test || failed=1
+fi
+
+if [ "$failed" -eq 0 ]; then
   CAPTURED_OUTPUT=""
   run_step_capture "API tests" bun run --filter @draftila/api test -- --coverage || failed=1
 


### PR DESCRIPTION
## What changed

Switching pages or reopening a draft used to reset the canvas to a default camera, losing wherever you were. Zoom level and scroll position are now persisted per `(draft, page)` in localStorage and restored on page switch, on reload, and on returning to a draft.

## Approach

Two new modules, split so the logic is testable without a DOM:

- **`apps/web/src/lib/camera-storage.ts`** - pure storage layer. One key per draft (`draftila:camera:<draftId>`), schema-versioned, with read-side validation, LRU caps (40 pages/draft, 30 drafts), quota handling, and viewport re-centring. The viewport is a parameter, never a DOM read.
- **`apps/web/src/pages/editor/lib/camera-session.ts`** - a pending map, one 500ms trailing timer, and a `{draftId, ydoc, getViewport}` triple. Owns the save pipeline and the page-entry decision.

Wired in via a `useCameraPersistence` hook, a single `useLayoutEffect` in the editor that owns page entry, and a synchronous apply inside `switchToPage`.

Continuous panning and zooming produce zero writes until the gesture pauses. Pending saves are flushed on page switch, tab close, and in-app navigation away.

## Design notes

- **Applied cameras are suppressed by object identity, not a flag.** Restores and fallbacks must never be recorded back as if they were user movement - otherwise persisting a fallback destroys the "nothing stored yet" state that zoom-to-fit-on-open depends on. Fallbacks spread `{...DEFAULT_CAMERA}` so the shared constant is never aliased.
- **Recording derives the page id from `getActivePageId(ydoc)`, never the store.** Closing the left panel unmounts `PageList`, which is what keeps the store's `activePageId` current; trusting it would silently persist nothing for an entire session.
- **The dedupe key includes the `ydoc` identity**, so restoring an old version (which rebuilds the doc under the same draft id, preserving page ids) correctly re-fits instead of skipping.
- **`useLayoutEffect`, not `requestAnimationFrame`** - the camera is applied before first paint, so page switches don't flash the outgoing camera.
- **Version preview is persistence-inert** - no reads, no writes - and exiting preview forces a re-apply so a pan made inside a preview can't become the live session's camera.

## Incidental fixes

- Zoom-to-fit no longer re-runs on every websocket reconnect (previously keyed on `synced`).
- An empty draft now gets a deterministic default camera instead of silently inheriting the previous draft's, via `fitCameraToAllShapes`' three silent early-outs.
- Stored cameras are cleaned up when a page or draft is deleted; anything missed is bounded by the LRU caps.

## Checklist

- [x] I confirm I have the right to contribute and I agree to `CONTRIBUTING.md`.
