### PR TITLE
[Fix] first PNG export dropping raster images

### DIFF
--- a/apps/api/src/modules/mcp/image-loader.ts
+++ b/apps/api/src/modules/mcp/image-loader.ts
@@ -2,7 +2,7 @@ import { lookup } from 'node:dns/promises';
 import { request as httpRequest } from 'node:http';
 import type { IncomingMessage, RequestOptions } from 'node:http';
 import { request as httpsRequest } from 'node:https';
-import { createCanvas, Image } from '@napi-rs/canvas';
+import { createCanvas, loadImage, type Image } from '@napi-rs/canvas';
 import { imageSize } from 'image-size';
 import { extractStorageKey, getStorage } from '../../common/lib/storage';
 
@@ -179,10 +179,13 @@ function getImageDimensions(bytes: Buffer): ReturnType<typeof imageSize> {
   return dimensions;
 }
 
-function decodeImage(bytes: Buffer): Image {
-  const image = new Image();
+// `image.src = bytes` fills in the header-derived metadata (`complete`, `naturalWidth`) straight
+// away but decodes the pixels on a later tick, so drawing the image in the same tick silently
+// paints nothing. `loadImage` resolves only once the pixels are actually there.
+async function decodeImage(bytes: Buffer): Promise<Image> {
+  let image: Image;
   try {
-    image.src = bytes;
+    image = await loadImage(bytes);
   } catch {
     throw new Error('Unsupported or unreadable image format');
   }
@@ -265,7 +268,7 @@ async function readImageBytes(src: string): Promise<Buffer> {
 export async function loadServerImageAsset(src: string): Promise<ServerImageAsset> {
   const bytes = await readImageBytes(src);
   const dimensions = getImageDimensions(bytes);
-  const image = decodeImage(bytes);
+  const image = await decodeImage(bytes);
   const extension = dimensions.type ? BROWSER_IMAGE_EXTENSIONS[dimensions.type] : undefined;
 
   if (extension) {
@@ -278,6 +281,6 @@ export async function loadServerImageAsset(src: string): Promise<ServerImageAsse
 export async function loadServerImage(src: string): Promise<HTMLImageElement> {
   const bytes = await readImageBytes(src);
   getImageDimensions(bytes);
-  const image = decodeImage(bytes);
+  const image = await decodeImage(bytes);
   return image as unknown as HTMLImageElement;
 }

--- a/apps/api/tests/modules/mcp-image-loader.test.ts
+++ b/apps/api/tests/modules/mcp-image-loader.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { deflateSync, crc32 } from 'node:zlib';
+import { createCanvas } from '@napi-rs/canvas';
 import { getStorage, initStorage } from '../../src/common/lib/storage';
 import {
   decodeDataUri,
@@ -150,6 +151,24 @@ describe('mcp image loader', () => {
       const uri = `data:image/png;base64,${Buffer.from('not an image').toString('base64')}`;
 
       await expect(loadServerImage(uri)).rejects.toThrow('Unsupported or unreadable image format');
+    });
+
+    test('returns an image whose pixels are drawable in the same tick', async () => {
+      const source = createCanvas(8, 8);
+      const sourceCtx = source.getContext('2d');
+      sourceCtx.fillStyle = '#ff0000';
+      sourceCtx.fillRect(0, 0, 8, 8);
+      const uri = `data:image/png;base64,${source.toBuffer('image/png').toString('base64')}`;
+
+      const image = await loadServerImage(uri);
+
+      // Setting `Image.src` resolves the metadata synchronously but decodes the pixels later, so a
+      // loader that does not await the decode hands back an image that draws as fully transparent.
+      const target = createCanvas(8, 8);
+      const targetCtx = target.getContext('2d');
+      targetCtx.drawImage(image as unknown as Parameters<typeof targetCtx.drawImage>[0], 0, 0);
+
+      expect([...targetCtx.getImageData(4, 4, 1, 1).data]).toEqual([255, 0, 0, 255]);
     });
   });
 


### PR DESCRIPTION
## What changed

- `decodeImage` in `apps/api/src/modules/mcp/image-loader.ts` is now async and uses `loadImage` instead of assigning `image.src`. It only returns once the pixels have actually been decoded, rather than as soon as the header has been parsed.
- Both callers, `loadServerImage` and `loadServerImageAsset`, now await it. They were already async so nothing else had to change.
- Added a regression test that draws a loaded image in the same tick and checks the pixels landed. It fails against the old code with a fully transparent result, which is the exact symptom.

This fixes the first `export_png` after a raster image is added coming back with the image missing. The old guard passed because `complete` and `naturalWidth` are populated from the header straight away, so an image with no pixel data got cached and drawn. See #69 for the full write up and a standalone repro.

SVG is unaffected either way, that path rasterises synchronously through resvg, so I've left it alone.

Closes #69

## Checklist

- [x] I confirm I have the right to contribute and I agree to `CONTRIBUTING.md`.
