### PR TITLE
[Fix] Inspect panel crashing on shapes with image fills

### DIFF
--- a/apps/web/src/pages/editor/components/inspect-panel/inspect-fill.tsx
+++ b/apps/web/src/pages/editor/components/inspect-panel/inspect-fill.tsx
@@ -32,7 +32,18 @@ export function InspectFill({ shape }: { shape: Shape }) {
       {visibleFills.map((fill, i) => {
         const indexLabel = visibleFills.length > 1 ? `Fill ${i + 1}` : null;
 
-        // Matches the renderer's precedence: an image fill paints over any colour it carries.
+        // Gradient, then image, then colour — the order fillToCssValue uses, so the List and
+        // Code tabs never disagree about which layer of a fill is the one on show.
+        if (fill.gradient) {
+          return (
+            <InspectPropertyRow
+              key={i}
+              label={indexLabel ?? 'Gradient'}
+              value={formatGradient(fill.gradient)}
+            />
+          );
+        }
+
         if (fill.imageSrc) {
           return (
             <div key={i} className="flex flex-col gap-0.5">
@@ -42,16 +53,6 @@ export function InspectFill({ shape }: { shape: Shape }) {
               />
               <InspectPropertyRow label="Source" value={fill.imageSrc} />
             </div>
-          );
-        }
-
-        if (fill.gradient) {
-          return (
-            <InspectPropertyRow
-              key={i}
-              label={indexLabel ?? 'Gradient'}
-              value={formatGradient(fill.gradient)}
-            />
           );
         }
 

--- a/apps/web/src/pages/editor/components/inspect-panel/inspect-fill.tsx
+++ b/apps/web/src/pages/editor/components/inspect-panel/inspect-fill.tsx
@@ -1,50 +1,69 @@
-import type { Shape } from '@draftila/shared';
+import type { Fill, Gradient, Shape } from '@draftila/shared';
 import { InspectSection } from './inspect-section';
 import { InspectPropertyRow } from './inspect-property-row';
 
-type ShapeWithFills = Shape & {
-  fills?: Array<{
-    color: string;
-    opacity: number;
-    visible: boolean;
-    gradient?: { type: string; stops: Array<{ color: string; position: number }> };
-  }>;
+type ShapeWithFills = Shape & { fills?: Fill[] };
+
+const IMAGE_FIT_LABELS: Record<NonNullable<Fill['imageFit']>, string> = {
+  fill: 'Fill',
+  fit: 'Fit',
+  crop: 'Crop',
+  tile: 'Tile',
 };
 
-function formatGradient(gradient: {
-  type: string;
-  stops: Array<{ color: string; position: number }>;
-}): string {
+function formatGradient(gradient: Gradient): string {
   const stops = gradient.stops.map((s) => s.color).join(', ');
   return `${gradient.type}(${stops})`;
+}
+
+function formatOpacity(opacity: number): string {
+  return opacity !== 1 ? ` ${Math.round(opacity * 100)}%` : '';
 }
 
 export function InspectFill({ shape }: { shape: Shape }) {
   const fills = (shape as ShapeWithFills).fills;
   if (!fills || fills.length === 0) return null;
 
-  const visibleFills = fills.filter((f) => f.visible);
+  const visibleFills = fills.filter((f) => f.visible && (f.imageSrc || f.gradient || f.color));
   if (visibleFills.length === 0) return null;
 
   return (
     <InspectSection title="Fill">
       {visibleFills.map((fill, i) => {
+        const indexLabel = visibleFills.length > 1 ? `Fill ${i + 1}` : null;
+
+        // Matches the renderer's precedence: an image fill paints over any colour it carries.
+        if (fill.imageSrc) {
+          return (
+            <div key={i} className="flex flex-col gap-0.5">
+              <InspectPropertyRow
+                label={indexLabel ?? 'Image'}
+                value={`${IMAGE_FIT_LABELS[fill.imageFit ?? 'fill']}${formatOpacity(fill.opacity)}`}
+              />
+              <InspectPropertyRow label="Source" value={fill.imageSrc} />
+            </div>
+          );
+        }
+
         if (fill.gradient) {
           return (
             <InspectPropertyRow
               key={i}
-              label={visibleFills.length > 1 ? `Fill ${i + 1}` : 'Gradient'}
+              label={indexLabel ?? 'Gradient'}
               value={formatGradient(fill.gradient)}
             />
           );
         }
-        const opacity = fill.opacity !== 1 ? ` ${Math.round(fill.opacity * 100)}%` : '';
+
+        const color = fill.color;
+        if (!color) return null;
+
         return (
           <InspectPropertyRow
             key={i}
-            label={visibleFills.length > 1 ? `Fill ${i + 1}` : 'Color'}
-            value={`${fill.color.toUpperCase()}${opacity}`}
-            colorSwatch={fill.color}
+            label={indexLabel ?? 'Color'}
+            value={`${color.toUpperCase()}${formatOpacity(fill.opacity)}`}
+            colorSwatch={color}
           />
         );
       })}


### PR DESCRIPTION
## What changed

- `InspectFill` now branches on `fill.imageSrc` before it reaches for `fill.color`, so an image fill no longer throws `Cannot read properties of undefined (reading 'toUpperCase')` and takes the whole editor down with it.
- Image fills get two rows of their own: the fit mode (Fill / Fit / Crop / Tile, defaulting to Fill) with the fill opacity, and the image source, which is copyable like every other row in the panel.
- Fills are resolved gradient, then image, then colour — the same order `fillToCssValue` uses in the CSS and Tailwind generators. Those generators are what the Code tab of this same panel renders from, so the two tabs can't end up disagreeing about which layer of a fill is the one on show. It's also the order the old code effectively used, so nothing that rendered before renders differently now.
- The component uses the shared `Fill` type instead of its own inline one. The local type declared `color: string` as required and didn't mention `imageSrc` at all, which is why the type checker was happy with the broken code. With the real type, the same mistake is a compile error.
- Fills with none of colour, gradient or image source are filtered out rather than rendered as an empty row, so a malformed fill can't take the panel down either.
- Opacity formatting is shared between the colour and image rows instead of being inlined.

Worth knowing for anyone looking at this area later: the canvas renderer resolves fills in the opposite order, trying the image first and falling back to the gradient or colour only when the image hasn't loaded. So a fill carrying both a gradient and an image source will paint as an image but read as a gradient in both Inspect tabs. That mismatch predates this change and isn't something a crash fix should quietly pick a side on, so I've left it alone.

Verified by rendering the component against solid, gradient, image, image-with-colour, gradient-with-image, mixed, hidden and empty fills. The image cases throw on the old code and pass on the new one. Full `bun run checks` is green.

Closes #71

## Checklist

- [x] I confirm I have the right to contribute and I agree to `CONTRIBUTING.md`.
